### PR TITLE
Dynamic NPC Index

### DIFF
--- a/map/abyssea.lua
+++ b/map/abyssea.lua
@@ -15,7 +15,7 @@ return T{
     zone_npc_list = function(type)
         local mlist = windower.ffxi.get_mob_list()
         mlist = table.filter(mlist, function(name)
-            return name ~= "" and npc_names[type]:any(string.startswith-{name})
+            return name ~= "" and npc_names[type]:any(string.startswith+{name})
         end)
         mlist = table.map(mlist, function(name)
             local num = name:match('%d+$')

--- a/map/abyssea.lua
+++ b/map/abyssea.lua
@@ -2,15 +2,27 @@ local warp_zones = S{ 232, 236, 240, 246, 243, 242 } -- ports + ru'lude and heav
 local entry_zones = S{ 102, 108, 117, 118, 103, 104, 107, 106, 112 } 
 local teleport_npcs = S{ "Ernst", "Ivan", "Willis", "Horst", "Kierron", "Vincent"}
 local abyssea_zones = S{ 15, 45, 132, 215, 216, 217, 218, 253, 254}
+local npc_names = T{
+    warp = S{'Veridical Conflux', 'Ernst', 'Ivan', 'Willis', 'Horst', 'Kierron', 'Vincent'},
+    enter = S{'Cavernous Maw'},
+    exit = S{'Cavernous Maw'},
+}
 return T{
     short_name = 'ab',
     long_name = 'veridical conflux',
     npc_plural = 'abyssean npcs',
-    npc_names = T{
-        warp = T{'Veridical Conflux', 'Ernst', 'Ivan', 'Willis', 'Horst', 'Kierron', 'Vincent'},
-        enter = T{'Cavernous Maw'},
-        exit = T{'Cavernous Maw'},
-    },
+    npc_names = npc_names,
+    zone_npc_list = function(type)
+        local mlist = windower.ffxi.get_mob_list()
+        mlist = table.filter(mlist, function(name)
+            return name ~= "" and npc_names[type]:any(string.startswith-{name})
+        end)
+        mlist = table.map(mlist, function(name)
+            local num = name:match('%d+$')
+            return {name=name, key=(num and tostring(num))}
+        end)
+        return mlist
+    end,
     validate = function(menu_id, zone, current_activity)
                 -- npc warps:
         if not (menu_id == 404 or --  Ernst

--- a/map/escha.lua
+++ b/map/escha.lua
@@ -1,15 +1,27 @@
 local entry_zones = S{126,25,102,108,117}
 local escha_zones = S{288,289,291}
+local npc_names = T{
+    warp = S{'Eschan Portal', 'Ethereal Ingress'},
+    enter = S{'Undulating Confluence', 'Dimensional Portal'},
+    domain = S{'Affi', 'Dremi', 'Shiftrix'},
+    exit= S{'Undulating Confluence', 'Dimensional Portal'},
+}
 return T{
     short_name = 'ew',
     long_name = 'eschan portal',
     npc_plural = 'eschan npcs',
-    npc_names = T{
-        warp = T{'Eschan Portal', 'Ethereal Ingress'},
-        enter = T{'Undulating Confluence', 'Dimensional Portal'},
-        domain = T{'Affi', 'Dremi', 'Shiftrix'},
-        exit= T{'Undulating Confluence', 'Dimensional Portal'},
-    },
+    npc_names = npc_names,
+    zone_npc_list = function(type)
+        local mlist = windower.ffxi.get_mob_list()
+        mlist = table.filter(mlist, function(name)
+            return name ~= "" and npc_names[type]:any(string.startswith-{name})
+        end)
+        mlist = table.map(mlist, function(name)
+            local num = name:match('%d+$')
+            return {name=name, key=(num and tostring(num))}
+        end)
+        return mlist
+    end,
     validate = function(menu_id, zone, current_activity)
         local destination = current_activity.activity_settings
         if not ( -- NPCs:

--- a/map/escha.lua
+++ b/map/escha.lua
@@ -14,7 +14,7 @@ return T{
     zone_npc_list = function(type)
         local mlist = windower.ffxi.get_mob_list()
         mlist = table.filter(mlist, function(name)
-            return name ~= "" and npc_names[type]:any(string.startswith-{name})
+            return name ~= "" and npc_names[type]:any(string.startswith+{name})
         end)
         mlist = table.map(mlist, function(name)
             local num = name:match('%d+$')

--- a/map/guides.lua
+++ b/map/guides.lua
@@ -9,7 +9,7 @@ return T{ -- option: 1
     zone_npc_list = function(type)
         local mlist = windower.ffxi.get_mob_list()
         mlist = table.filter(mlist, function(name)
-            return name ~= "" and npc_names[type]:any(string.startswith-{name})
+            return name ~= "" and npc_names[type]:any(string.startswith+{name})
         end)
         mlist = table.map(mlist, function(name)
             return {name=name}

--- a/map/guides.lua
+++ b/map/guides.lua
@@ -1,10 +1,21 @@
+local npc_names = T{
+    warp = S{'Survival Guide'},
+}
 return T{ -- option: 1
     short_name = 'sg',
     long_name = 'survival guide',
     npc_plural = 'survival guides',
-    npc_names = T{
-        warp = T{'Survival Guide'},
-    },
+    npc_names = npc_names,
+    zone_npc_list = function(type)
+        local mlist = windower.ffxi.get_mob_list()
+        mlist = table.filter(mlist, function(name)
+            return name ~= "" and npc_names[type]:any(string.startswith-{name})
+        end)
+        mlist = table.map(mlist, function(name)
+            return {name=name}
+        end)
+        return mlist
+    end,
     validate = function(menu_id, zone, current_activity)
         if not(menu_id == 8500 or menu_id == 8501) then
             return "Incorrect menu detected! Menu ID: "..menu_id

--- a/map/homepoints.lua
+++ b/map/homepoints.lua
@@ -10,7 +10,7 @@ return T{ -- option: 2
     zone_npc_list = function(type)
         local mlist = windower.ffxi.get_mob_list()
         mlist = table.filter(mlist, function(name)
-            return name ~= "" and npc_names[type]:any(string.startswith-{name})
+            return name ~= "" and npc_names[type]:any(string.startswith+{name})
         end)
         mlist = table.map(mlist, function(name)
             local num = name:match('%d+$')

--- a/map/homepoints.lua
+++ b/map/homepoints.lua
@@ -1,11 +1,23 @@
+local npc_names = T{
+    warp = S{'Home Point'},
+    set = S{'Home Point'},
+}
 return T{ -- option: 2
     short_name = 'hp',
     long_name = 'homepoint',
     npc_plural = 'homepoints',
-    npc_names = T{
-        warp = T{'Home Point'},
-        set = T{'Home Point'},
-    },
+    npc_names = npc_names,
+    zone_npc_list = function(type)
+        local mlist = windower.ffxi.get_mob_list()
+        mlist = table.filter(mlist, function(name)
+            return name ~= "" and npc_names[type]:any(string.startswith-{name})
+        end)
+        mlist = table.map(mlist, function(name)
+            local num = name:match('%d+$')
+            return {name=name, key=(num and tostring(num))}
+        end)
+        return mlist
+    end,
     validate = function(menu_id, zone, current_activity)
         if not(menu_id >= 8700 and menu_id <= 8704) then
             return "Incorrect menu detected! Menu ID: "..menu_id

--- a/map/maps.lua
+++ b/map/maps.lua
@@ -1,4 +1,4 @@
-return {
+local maps =  {
     ['homepoints'] = require('map/homepoints'),
     ['waypoints'] = require('map/waypoints'),
     ['guides'] = require('map/guides'),
@@ -10,3 +10,15 @@ return {
     ['voidwatch'] = require('map/voidwatch'),
 	['spd'] = require('map/spd'),
 }
+
+for _, map in pairs(maps) do
+    for zone_name, zone_data in pairs(map.warpdata) do
+        if not zone_data.index then
+            for key, npc in pairs(zone_data) do
+                npc.key = key
+            end
+        end
+    end
+end
+
+return maps

--- a/map/portals.lua
+++ b/map/portals.lua
@@ -1,12 +1,23 @@
+local npc_names = T{
+    warp = S{'Runic Portal'},
+    ['return'] = S{'Runic Portal'},
+    assault = S{'Runic Portal'},
+}
 return T{
     short_name = 'po',
     long_name = 'runic portal',
     npc_plural = 'runic portals',
-    npc_names = T{
-        warp = T{'Runic Portal'},
-        ['return'] = T{'Runic Portal'},
-        assault = T{'Runic Portal'},
-    },
+    npc_names = npc_names,
+    zone_npc_list = function(type)
+        local mlist = windower.ffxi.get_mob_list()
+        mlist = table.filter(mlist, function(name)
+            return name ~= "" and npc_names[type]:any(string.startswith-{name})
+        end)
+        mlist = table.map(mlist, function(name)
+            return {name=name}
+        end)
+        return mlist
+    end,
     validate = function(menu_id, zone, current_activity)
         if (current_activity.sub_cmd == nil or current_activity.sub_cmd == 'assault') and zone ~= 50 then
             return "Not in Whitegate!"

--- a/map/portals.lua
+++ b/map/portals.lua
@@ -11,7 +11,7 @@ return T{
     zone_npc_list = function(type)
         local mlist = windower.ffxi.get_mob_list()
         mlist = table.filter(mlist, function(name)
-            return name ~= "" and npc_names[type]:any(string.startswith-{name})
+            return name ~= "" and npc_names[type]:any(string.startswith+{name})
         end)
         mlist = table.map(mlist, function(name)
             return {name=name}

--- a/map/protowaypoints.lua
+++ b/map/protowaypoints.lua
@@ -1,10 +1,21 @@
+local npc_names = T{
+    warp = S{'Proto-Waypoint'},
+}
 return T{
     short_name = 'pwp',
     long_name = 'proto-waypoint',
     npc_plural = 'proto-waypoints',
-    npc_names = T{
-        warp = T{'Proto-Waypoint'},
-    },
+    npc_names = npc_names,
+    zone_npc_list = function(type)
+        local mlist = windower.ffxi.get_mob_list()
+        mlist = table.filter(mlist, function(name)
+            return name ~= "" and npc_names[type]:any(string.startswith-{name})
+        end)
+        mlist = table.map(mlist, function(name)
+            return {name}
+        end)
+        return mlist
+    end,
     validate = function(menu_id, zone, current_activity)
         if not (menu_id == 10209 or -- Ru'Lude Gardens
                menu_id == 10012 or -- Selbina

--- a/map/protowaypoints.lua
+++ b/map/protowaypoints.lua
@@ -9,7 +9,7 @@ return T{
     zone_npc_list = function(type)
         local mlist = windower.ffxi.get_mob_list()
         mlist = table.filter(mlist, function(name)
-            return name ~= "" and npc_names[type]:any(string.startswith-{name})
+            return name ~= "" and npc_names[type]:any(string.startswith+{name})
         end)
         mlist = table.map(mlist, function(name)
             return {name}

--- a/map/spd.lua
+++ b/map/spd.lua
@@ -10,7 +10,7 @@ return T{
     zone_npc_list = function(type)
         local mlist = windower.ffxi.get_mob_list()
         mlist = table.filter(mlist, function(name)
-            return name ~= "" and npc_names[type]:any(string.startswith-{name})
+            return name ~= "" and npc_names[type]:any(string.startswith+{name})
         end)
         mlist = table.map(mlist, function(name)
             return {name=name}

--- a/map/spd.lua
+++ b/map/spd.lua
@@ -1,12 +1,22 @@
 local entry_zones = S{ 29 } 
-
+local npc_names = T{
+    enter = S{'Spatial Displacement'},
+}
 return T{
     short_name = 'spd',
     long_name = 'spatial displacement',
     npc_plural = 'displacements',
-    npc_names = T{
-        enter = T{'Spatial Displacement'},
-    },
+    npc_names = npc_names,
+    zone_npc_list = function(type)
+        local mlist = windower.ffxi.get_mob_list()
+        mlist = table.filter(mlist, function(name)
+            return name ~= "" and npc_names[type]:any(string.startswith-{name})
+        end)
+        mlist = table.map(mlist, function(name)
+            return {name=name}
+        end)
+        return mlist
+    end,
     validate = function(menu_id, zone, current_activity)
         -- check menu id here.
 		if not (  menu_id == 33) then

--- a/map/unity.lua
+++ b/map/unity.lua
@@ -11,7 +11,7 @@ return T{ -- option: 1
     zone_npc_list = function(type)
         local mlist = windower.ffxi.get_mob_list()
         mlist = table.filter(mlist, function(name)
-            return name ~= "" and npc_names[type]:any(string.startswith-{name})
+            return name ~= "" and npc_names[type]:any(string.startswith+{name})
         end)
         mlist = table.map(mlist, function(name)
             return {name=name}

--- a/map/unity.lua
+++ b/map/unity.lua
@@ -1,3 +1,6 @@
+local npc_names = T{
+    warp = S{"Igsli", "Urbiolaine", "Teldro-Kesdrodo", "Yonolala", "Nunaarl Bthtrogg"},
+}
 return T{ -- option: 1
     short_name = 'un',
     long_name = 'unity',
@@ -5,6 +8,16 @@ return T{ -- option: 1
     npc_names = T{
         warp = T{"Igsli", "Urbiolaine", "Teldro-Kesdrodo", "Yonolala", "Nunaarl Bthtrogg"},
     },
+    zone_npc_list = function(type)
+        local mlist = windower.ffxi.get_mob_list()
+        mlist = table.filter(mlist, function(name)
+            return name ~= "" and npc_names[type]:any(string.startswith-{name})
+        end)
+        mlist = table.map(mlist, function(name)
+            return {name=name}
+        end)
+        return mlist
+    end,
     validate = function(menu_id, zone, current_activity)
         if not(menu_id == 598 or -- Igsli
                menu_id == 3529 or -- Urbiolaine

--- a/map/voidwatch.lua
+++ b/map/voidwatch.lua
@@ -1,13 +1,24 @@
 local past_warp_zones = S{80,84,87,91,94,98}
 local menu_ids = S{962, 1023, 264, 16, 316, 49, 627, 24, 7, 6, -- present
                    79, 657, 46, 25, 8, 15} -- shadowreign
+local npc_names = T{
+    warp = S{"Atmacite Refiner"},
+}
 return T{ --  index: 1
     short_name = 'vw',
     long_name = 'voidwatch',
     npc_plural = 'atmacite refiners',
-    npc_names = T{
-        warp = T{"Atmacite Refiner"},
-    },
+    npc_names = npc_names,
+    zone_npc_list = function(type)
+        local mlist = windower.ffxi.get_mob_list()
+        mlist = table.filter(mlist, function(name)
+            return name ~= "" and npc_names[type]:any(string.startswith-{name})
+        end)
+        mlist = table.map(mlist, function(name)
+            return {name=name}
+        end)
+        return mlist
+    end,
     validate = function(menu_id, zone, current_activity)
         local destination = current_activity.activity_settings
         if not menu_ids:contains(menu_id) then 

--- a/map/voidwatch.lua
+++ b/map/voidwatch.lua
@@ -12,7 +12,7 @@ return T{ --  index: 1
     zone_npc_list = function(type)
         local mlist = windower.ffxi.get_mob_list()
         mlist = table.filter(mlist, function(name)
-            return name ~= "" and npc_names[type]:any(string.startswith-{name})
+            return name ~= "" and npc_names[type]:any(string.startswith+{name})
         end)
         mlist = table.map(mlist, function(name)
             return {name=name}

--- a/map/waypoints.lua
+++ b/map/waypoints.lua
@@ -1,10 +1,39 @@
+npc_names = T{
+    warp = S{'Waypoint'},
+}
 return T{
     short_name = 'wp',
     long_name = 'waypoint',
     npc_plural = 'waypoints',
-    npc_names = T{
-        warp = T{'Waypoint'},
-    },
+    npc_names = npc_names,
+    zone_npc_list = function(type)
+        local mlist = windower.ffxi.get_mob_list()
+        mlist = table.filter(mlist, function(name)
+            return name ~= "" and npc_names[type]:any(string.startswith-{name})
+        end)
+        if table.length(mlist) <= 1 then
+            mlist = table.map(mlist, function(name)
+                return {name=name}
+            end)
+        else
+            temp_list = L{}
+            for index, name in pairs(mlist) do
+                temp_list:append(index)
+            end
+            temp_list:sort()
+            mlist = table.map(mlist, function(name)
+                return {name=name}
+            end)
+            for index, number in temp_list:it() do
+                if number == 1 then
+                    mlist[index].key = "Frontier Station"
+                else
+                    mlist[index].key = tostring(number-1)
+                end
+            end
+        end
+        return mlist
+    end,
     validate = function(menu_id, zone, current_activity)
         if not ((menu_id >= 5000 and menu_id <= 5008) or menu_id == 10121) then
             return "Incorrect menu detected! Menu ID: "..menu_id

--- a/map/waypoints.lua
+++ b/map/waypoints.lua
@@ -9,7 +9,7 @@ return T{
     zone_npc_list = function(type)
         local mlist = windower.ffxi.get_mob_list()
         mlist = table.filter(mlist, function(name)
-            return name ~= "" and npc_names[type]:any(string.startswith-{name})
+            return name ~= "" and npc_names[type]:any(string.startswith+{name})
         end)
         if table.length(mlist) <= 1 then
             mlist = table.map(mlist, function(name)

--- a/map/waypoints.lua
+++ b/map/waypoints.lua
@@ -1,6 +1,7 @@
 npc_names = T{
     warp = S{'Waypoint'},
 }
+local adoulin = S(require('resources').zones:en(string.endswith-{' Adoulin'}):map(table.get-{'id'}))
 return T{
     short_name = 'wp',
     long_name = 'waypoint',
@@ -8,6 +9,7 @@ return T{
     npc_names = npc_names,
     zone_npc_list = function(type)
         local mlist = windower.ffxi.get_mob_list()
+        local zone = windower.ffxi.get_info().zone
         mlist = table.filter(mlist, function(name)
             return name ~= "" and npc_names[type]:any(string.startswith+{name})
         end)
@@ -25,10 +27,14 @@ return T{
                 return {name=name}
             end)
             for index, number in temp_list:it() do
-                if number == 1 then
-                    mlist[index].key = "Frontier Station"
+                if not adoulin:contains(zone) then
+                    if number == 1 then
+                        mlist[index].key = "Frontier Station"
+                    else
+                        mlist[index].key = tostring(number-1)
+                    end
                 else
-                    mlist[index].key = tostring(number-1)
+                    mlist[index].key = tostring(number)
                 end
             end
         end

--- a/superwarp.lua
+++ b/superwarp.lua
@@ -42,7 +42,7 @@ _addon.name = 'superwarp'
 
 _addon.author = 'Akaden'
 
-_addon.version = '0.97.9'
+_addon.version = '0.98.0'
 
 _addon.commands = {'sw','superwarp'}
 
@@ -373,7 +373,7 @@ local function find_npc(needles)
         if npc and npc.valid_target and (not target_npc or npc.distance < distance) then
             target_npc = npc
             distance = npc.distance
-            npc_key = npc.key
+            npc_key = npc_data.key
         end
     end
     return target_npc, distance, npc_key
@@ -461,7 +461,7 @@ local function do_warp(map_name, zone, sub_zone)
     local warp_settings, display_name = resolve_warp(map_name, zone, sub_zone)
     if warp_settings and warp_settings.index then
         local npc, dist, npc_key = find_npc(map.zone_npc_list('warp'))
-        warp_settings.npc = npc.index
+        warp_settings.npc = npc and npc.index or warp_settings.npc
 
         if not npc then
             if state.loop_count > 0 then

--- a/superwarp.lua
+++ b/superwarp.lua
@@ -367,17 +367,17 @@ end
 local function find_npc(needles)
     local target_npc = nil
     local distance = nil
-    local p = windower.ffxi.get_mob_by_target("me")
-    for i, v in pairs(windower.ffxi.get_mob_array()) do
-        local d = distance_sqd(windower.ffxi.get_mob_by_index(i), p)
-        for i, needle in ipairs(needles) do
-            if v.valid_target and (not target_npc or d < distance) and string.find(get_fuzzy_name(v.name), "^"..get_fuzzy_name(needle)) then
-                target_npc = v
-                distance = d
-            end
+    local npc_key = nil
+    for index, npc_data in pairs(needles) do
+        local npc = windower.ffxi.get_mob_by_index(index)
+        print(index, npc and npc.distance)
+        if npc and npc.valid_target and (not target_npc or npc.distance < distance) then
+            target_npc = npc
+            distance = npc.distance
+            npc_key = npc.key
         end
     end
-    return target_npc, distance
+    return target_npc, distance, npc_key
 end
 
 -- Thanks to Ivaar for these two:
@@ -461,8 +461,10 @@ local function do_warp(map_name, zone, sub_zone)
 
     local warp_settings, display_name = resolve_warp(map_name, zone, sub_zone)
     if warp_settings and warp_settings.index then
-        local npc, dist = find_npc(map.npc_names.warp)
+        local npc, dist, npc_key = find_npc(map.zone_npc_list('warp'))
+        warp_settings.npc = npc.index
 
+        print('!', warp_settings.key, npc_key)
         if not npc then
             if state.loop_count > 0 then
                 log('No ' .. map.npc_plural .. ' found! Retrying...')
@@ -479,7 +481,7 @@ local function do_warp(map_name, zone, sub_zone)
             else
                 log(npc.name .. ' found, but too far!')
             end
-        elseif (warp_settings.npc == nil or warp_settings.npc == npc.index) and warp_settings.zone == windower.ffxi.get_info()['zone'] then
+        elseif (npc_key and warp_settings.key == npc_key) and warp_settings.zone == windower.ffxi.get_info()['zone'] then
             log("You are already at "..display_name.."! Teleport canceled.")
             state.loop_count = 0
         elseif npc.id and npc.index then
@@ -496,7 +498,7 @@ end
 local function do_sub_cmd(map_name, sub_cmd, args)
     local map = maps[map_name]
 
-    local npc, dist = find_npc(map.npc_names[sub_cmd])
+    local npc, dist = find_npc(map.zone_npc_list(sub_cmd))
 
     if not npc then
         if state.loop_count > 0 then
@@ -523,7 +525,7 @@ end
 
 local function do_find_missing_destinations(map_name, args)
     local map = maps[map_name]
-    local npc, dist = find_npc(map.npc_names.warp)
+    local npc, dist = find_npc(map.zone_npc_list('warp'))
 
     if not npc then
         if state.loop_count > 0 then

--- a/superwarp.lua
+++ b/superwarp.lua
@@ -370,7 +370,6 @@ local function find_npc(needles)
     local npc_key = nil
     for index, npc_data in pairs(needles) do
         local npc = windower.ffxi.get_mob_by_index(index)
-        print(index, npc and npc.distance)
         if npc and npc.valid_target and (not target_npc or npc.distance < distance) then
             target_npc = npc
             distance = npc.distance
@@ -464,7 +463,6 @@ local function do_warp(map_name, zone, sub_zone)
         local npc, dist, npc_key = find_npc(map.zone_npc_list('warp'))
         warp_settings.npc = npc.index
 
-        print('!', warp_settings.key, npc_key)
         if not npc then
             if state.loop_count > 0 then
                 log('No ' .. map.npc_plural .. ' found! Retrying...')


### PR DESCRIPTION
In zone "already at this point" detection now relies on NPC name or relative NPC index rather than hardcoded indexes.
I have left the old indexes in the files, but they are now updated in the data structure on the fly when a warp is requested by the user.