### PR TITLE
Workaround for FFXI bug where FFXI does not properly set valid_target

### DIFF
--- a/superwarp.lua
+++ b/superwarp.lua
@@ -56,6 +56,7 @@ packets = require('packets')
 require('coroutine')
 config = require('config')
 resources = require('resources')
+require('vectors')
 
 require('sendall')
 require('fuzzyfind')

--- a/superwarp.lua
+++ b/superwarp.lua
@@ -371,12 +371,19 @@ local function find_npc(needles)
     local target_npc = nil
     local distance = nil
     local npc_key = nil
+    local me = windower.ffxi.get_mob_by_target('me')
+    local vec = V{}
     for index, npc_data in pairs(needles) do
         local npc = windower.ffxi.get_mob_by_index(index)
-        if npc and npc.valid_target and (not target_npc or npc.distance < distance) then
-            target_npc = npc
-            distance = npc.distance
-            npc_key = npc_data.key
+        if npc and npc.valid_target then
+            vec[1] = npc.x - me.x
+            vec[2] = npc.y - me.y
+            local npc_distance = vec:length()
+            if not target_npc or (npc_distance < distance) then
+                target_npc = npc
+                distance = npc_distance
+                npc_key = npc_data.key
+            end
         end
     end
     return target_npc, distance, npc_key


### PR DESCRIPTION
It appears that in Limbus the data in the mob structure is bad. The valid_target flag is not properly being set to false. This results in superwarp attempting to poke the wrong warp npcs depending on your distance to the new npc vs the distance from the previous one.

This works around this FFXI bug by computing the distance from your current position and the each warp npc instead of relying on the data in the mob array.