### PR TITLE
Sortie.lua warp packets update.

### DIFF
--- a/map/sortie.lua
+++ b/map/sortie.lua
@@ -620,7 +620,6 @@ return T {
             expecting_zone = false,
             delay = 0.5,
             description = 'complete menu'
-
         })
 
             return actions


### PR DESCRIPTION
SE made a change to the packets exchanged while interacting with bitzers, devices, gadgets. They have yet to update the spawn conditions for chest in H and nakuuls and such as of this pull request but what will happen next is they will make that adjustment to what spawns those things and keep this packet structure that they just changed to; This should be the only update that is needed for sortie.