### PR TITLE
Version 1.1.1 - Waypoints search fix , Sortie basement re-entry fix, Limbus bugfixes, Mog Garden added, Manual Limbus chest ordering command, chest syncing command and much more ..

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,3 +322,8 @@ Thanks to Staticvoid for researching and implementing the Sortie, Odyssey, Temen
 - **Resolved**: An issue wherein loading or reloading superwarp on multiple characters simultaneously could flash the settings.xml file, resetting to default values. Each character now has their own xml file.
 - **Resolved**: An issue that could cause the user to freeze or crash when touching a warp device, accidentally or otherwise, while superwarp was active.
 - **Resolved**: Minor bugs.
+
+#### v1.1.1
+- **Feature**: Waypoints now accept partially typed destination names for all locations, not just the zone names. Go ahead and type //sw mumm  to go to Mummers' Coalition  or //sw pion  to go to Pioneers' Coalition etc. Superwarp will now know what you meant :D
+- **Resolved**: A bug where limbus chest tracking could become imperfect if the determined next chest was not opened.
+- **Improvement**: NPC distance measurement and requirement.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The //sw command prefix can now be used for all maps. It may still be used in th
 | //sw missing | Displays the destinations the user is missing from the warp system nearest you where applicable. |
 |(New!) //sw default / hpdefault | Toggles default homepoint destinations between Legacy and New. |
 |(New!) //sw display | Toggles sendall confirmation display. |
+|(New!) //sw chest (tower) / chest |  -- Manually updates chest tracking with the tower you input after the chest command. i.e. //sw chest nw or sw/ne/se/n/w/e/c; If no argument is provided after 'chest' it will display the next chest open location while in limbus. |
+|(New!) //sw chestsync / syncchest / sync | Instantly synchronizes all characters' Limbus chest tracking order with the character the command is executed from, ensuring all characters warp to the same destination. |
 | //sw cancel [all/party]  | Cancels the current in-progress warp.   |
 | //sw reset [all/party]  | Resets client menu lock. This should be exceedingly rare, but it's here in case it's needed.   |
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,11 @@ The //sw command prefix can now be used for all maps. It may still be used in th
 |//[sw] woe [all/party] exit | Exit a battlefield inside Walk Of Echoes. "all" and "party" will send an ipc message to all local instances (or specific local party members) with a delay (otherwise it will get stuck).
 |alt cmd: we |
 
+#### Mog Garden (New!)
+| Command | Action |
+| --- | --- |
+|//[sw] mg [all/party] zone | Enter Mog Garden from Eastern/Western Adoulin or Mog Dinghy in a Port zone or exit Mog Garden from Mog Dinghy. "all" and "party" will send an ipc message to all local instances (or specific local party members) with a delay (otherwise it will get stuck).
+
 ### Fuzzy Zone Names
 
 Spaces and punctuation are ignored. So type "southernsand" all you want, buddy. You're going to Southern San d'oria. Also, if you ommit the homepoint/waypoint number, it'll just take the first one in the map. Favorites are available in the settings file (example follows):
@@ -216,7 +221,7 @@ Thanks to Lili for researching a better fuzzy matching logic.
 Thanks to Staticvoid for researching and implementing the Sortie, Odyssey, Temenos, Apollyon and Campaign warp systems.
 
 ### Updates
-#### v0.96
+#### v0.96.0
 - **Feature**: Homepoints now uses same-zone teleporting feature.
 - **Feature**: Homepoints now check enabled expansion content before warping. Before, if you warped to a zone that came in an expansion that is not enabled or installed, the character would get stuck until the expansion was enabled and installed.
 - **Feature**: All warp systems check the currency required to teleport before teleporting. 
@@ -329,10 +334,13 @@ Thanks to Staticvoid for researching and implementing the Sortie, Odyssey, Temen
 - **Resolved**: An issue that could cause the user to freeze or crash when touching a warp device, accidentally or otherwise, while superwarp was active.
 - **Resolved**: Minor bugs.
 
-#### v1.1.1
+#### v1.1.1+ (Post-Release Additions)
 - **Feature**: Waypoints now accept partially typed destination names for all locations, not just the zone names. Go ahead and type //sw mumm  to go to Mummers' Coalition  or //sw pion  to go to Pioneers' Coalition etc. superwarp will now know what you meant :D
+- **Feature**: Mog Garden added! (//mg zone) when near the Mog Garden entrance NPC in Eastern or Western Adoulin or a Mog Dinghy in a port zone; Exit your Mog Garden with the same command near the Mog Dinghy inside. (//sw in place of //mg zone )
 - **Feature**: A command has been added to toggle the default homepoint for popular zones between 'Legacy' and 'New', //sw default.
 - **Feature**: A command has been added to toggle the display of all / party warp progress, //sw display.
+- **Feature**: A command has been added to instantly synchronize the chest tracking data of all characters with the character the command is sent from, ensuring all characters warp to the same location with the 'next' and 'random' commands within Limbus. //sw sync
+- **Feature**: A command has been added to manually set the order of your chest tracking, or if no argument is provided after //sw chest   it will display the next chest to be opened while within Limbus. //sw chest (tower) i.e. //sw chest nw  or  //sw chest c
 - **Feature**: A small translucent box has been added that shows the progress of 'all' or 'party' warps in addition to chatlog messages that report the results. (Only applies to 'all' or 'party' warps.) The box vanishes after 15 seconds or upon confirming all warps.
 - **Improvement**: Sortie warp object unlock checks are no longer delayed on account of dependence on inventory loading for temp item check, but instead are done instantly upon interacting with them.
 - **Improvement**: CN destinations added to Limbus map with appropriate open checks.

--- a/README.md
+++ b/README.md
@@ -3,11 +3,22 @@
 This is an addon for Windower4 for FFXI. It allows text commands to teleport using Homepoints, Waypoints, Proto-Waypoints, Survival Guides, Escha Portals and Reisenjima Ingresses, Voidwatch and Unity NPCs, Abyssea Confluxes, Runic Portals, Odyssey Confluxes and Translocators, and Sortie Gadgets, Bitzers, and Devices, Temenos Matter Diffusion Modules and Apollyon Swirling Vortices, Incursion Rusted Transmitters, Walk Of Echoes Confluxes.
 
 ### Commands:
+The //sw command prefix can now be used for all maps. It may still be used in the manner it was previously if the user so desired.
+
+#### Misc. Commands
+| Command | Action |
+| --- | --- |
+| //sw debug  | Toggles debug mode which displays debug messages in the log. If debug mode was off, will display the debug logs of the last warp command as well.   |
+| //sw missing | Displays the destinations the user is missing from the warp system nearest you where applicable. |
+|(New!) //sw default / hpdefault | Toggles default homepoint destinations between Legacy and New. |
+|(New!) //sw display | Toggles sendall confirmation display. |
+| //sw cancel [all/party]  | Cancels the current in-progress warp.   |
+| //sw reset [all/party]  | Resets client menu lock. This should be exceedingly rare, but it's here in case it's needed.   |
 
 #### The superwarp™ (New!)
 | Command | Action |
 | --- | --- |
-| //sw [a/p]  One command to rule them all. Passes the appropriate command for the circumstance. Some users might consider a hotkey for this, like alt + S to pass the smartcommand with no typing and no macro. "all" and "party" will send an ipc message to all local instances (or specific local party members) with a delay (otherwise it will get stuck).
+| //sw [a/p]  One command to rule them all. Passes the appropriate command for the circumstance. Some users might consider a hotkey for this, like alt + S to pass the smartcommand with no typing and no macro and  ctrl + alt + S to pass the smartcommand to all party members (sw p) . "all" and "party" will send an ipc message to all local instances (or specific local party members) with a delay (otherwise it will get stuck).
 
 ---
 
@@ -129,14 +140,6 @@ This is an addon for Windower4 for FFXI. It allows text commands to teleport usi
 |//[sw] woe [all/party] enter | Enter a battlefield you are standing within 6 yalms of while inside Walk Of Echoes. (There is no point at which more than one conflux is <= 6 yalms.) "all" and "party" will send an ipc message to all local instances (or specific local party members) with a delay (otherwise it will get stuck).
 |//[sw] woe [all/party] exit | Exit a battlefield inside Walk Of Echoes. "all" and "party" will send an ipc message to all local instances (or specific local party members) with a delay (otherwise it will get stuck).
 |alt cmd: we |
-
-#### Misc. Commands
-| Command | Action |
-| --- | --- |
-| //sw debug  | Toggles debug mode which displays debug messages in the log. If debug mode was off, will display the debug logs of the last warp command as well.   |
-| //sw missing | Displays the destinations the user is missing from the warp system nearest you where applicable. |
-| //sw cancel [all/party]  | Cancels the current in-progress warp.   |
-| //sw reset [all/party]  | Resets client menu lock. This should be exceedingly rare, but it's here in case it's needed.   |
 
 ### Fuzzy Zone Names
 
@@ -312,7 +315,7 @@ Thanks to Staticvoid for researching and implementing the Sortie, Odyssey, Temen
 - **Feature**: Incursion warp system added.
 - **Feature**: Walk Of Echoes warp system added.
 - **Feature**: New command (port) added to Campaign map to travel back and forward through Cavernous Maws.
-- **Improvement**: Homepoints now defaults to the most popular homepoint of frequently visited zones when a sub-command is not specified; This allows the user to leverage the fuzzyfind feature and command interpretation to execute common warps with very little typing. Examples - '//sw no' = Norg #2, '//sw eas' = Eastern Adoulin #2 with no custom alias configuration. 
+- **Improvement**: In 'New' mode. (//sw default) Homepoints now defaults to the most popular homepoint of frequently visited zones when a sub-command is not specified; This allows the user to leverage the fuzzyfind feature and command interpretation to execute common warps with very little typing. Examples - '//sw nor' = Norg #2, '//sw eas' = Eastern Adoulin #2 with no custom alias configuration. 
 - **Improvement**: Waypoints now default to the Frontier Station of non-town zones when a sub-zone destination is not given, defaults to AH for Eastern Adoulin, and MH for Western Adoulin.
 - **Improvement**: (Waypoints) Shortcut added to more easily travel to Frontier Station; There are now multiple accepted inputs such as 'front' and 'frontier' to go these WPs. Some users may have struggled with this in the past if unaware of the pre-programmed 'fs' alias.
 - **Improvement**: Smart command. '//sw' Sortie Device warps now use logic to take the user to the next logical destination for a 9-Boss run based on main job and progress in the run. DHABCGFE. (Corsair gets sent to B if they do not have B shard, start if they do etc). Because of this it is possible to use one command for the entire 9boss run. /console sw  or  //sw   or hotkey Alt + S (sw)
@@ -325,6 +328,18 @@ Thanks to Staticvoid for researching and implementing the Sortie, Odyssey, Temen
 - **Resolved**: Minor bugs.
 
 #### v1.1.1
-- **Feature**: Waypoints now accept partially typed destination names for all locations, not just the zone names. Go ahead and type //sw mumm  to go to Mummers' Coalition  or //sw pion  to go to Pioneers' Coalition etc. Superwarp will now know what you meant :D
+- **Feature**: Waypoints now accept partially typed destination names for all locations, not just the zone names. Go ahead and type //sw mumm  to go to Mummers' Coalition  or //sw pion  to go to Pioneers' Coalition etc. superwarp will now know what you meant :D
+- **Feature**: A command has been added to toggle the default homepoint for popular zones between 'Legacy' and 'New', //sw default.
+- **Feature**: A command has been added to toggle the display of all / party warp progress, //sw display.
+- **Feature**: A small translucent box has been added that shows the progress of 'all' or 'party' warps in addition to chatlog messages that report the results. (Only applies to 'all' or 'party' warps.) The box vanishes after 15 seconds or upon confirming all warps.
+- **Improvement**: Sortie warp object unlock checks are no longer delayed on account of dependence on inventory loading for temp item check, but instead are done instantly upon interacting with them.
+- **Improvement**: CN destinations added to Limbus map with appropriate open checks.
+- **Improvement**: The reset / cancel command (manual reset) now sets retries to 0, so it ends a warp command.
+- **Improvement**: NPC distance measurement improvements.
+- **Improvement**: sendall warp operation time has been reduced.
+- **Improvement**: Warp success rate while being attacked has been greatly increased.
+- **Resolved**: A bug where the user could wind up stuck on a floor in limbus, getting the message "Nothing out of the ordinary here." when touching the elevators.
+- **Resolved**: A bug that could occur due to interrupts / retries where the user could change floors in limbus and have a missing data bar. (Still possible if attacked and interrupted at the right time, but very unlikely and only in favor of ensuring the aforementioned bug cannot occur.)
+- **Resolved**: A bug that could occur due to interrupts / retries where the user could re-enter the basement in Sortie, each warp command and its retries are now invariably locked to a single NPC. Warps will now auto-cancel if a different NPC is detected after warping. Rest easy exiting Sortie basements even under heavy attack. :)
+- **Resolved**: A bug involving interrupt / retries wherein a warp's subcommand could get dropped, changing the warp to a stardard warp with a default destination - in the case of limbus this would result in (protected) attempt(s) to warp to W1 in Temenos or NE5 attempt(s) in Apollyon, which are in essence default destinations respectively.
 - **Resolved**: A bug where limbus chest tracking could become imperfect if the determined next chest was not opened.
-- **Improvement**: NPC distance measurement and requirement.

--- a/map/abyssea.lua
+++ b/map/abyssea.lua
@@ -32,7 +32,7 @@ return T{
     validate = function(menu_id, zone, current_activity, p)
         local destination = current_activity.activity_settings
         local npcindex = p['NPC Index']
-        if current_activity.sub_cmd ~= 'exit' then
+        if current_activity.sub_cmd ~= 'exit' and current_activity.sub_cmd ~= 'enter' then
             if abyssea_zones:contains(zone) then
                 if npcindex == destination.npcindex then
                     return "You are already at that location."

--- a/map/garden.lua
+++ b/map/garden.lua
@@ -1,0 +1,85 @@
+local entry_zones = S{ 232, 236, 240, 256, 257, 280 }
+local npc_names = T{
+    zone = S{'Mog Dinghy','Cunegonde','Dangueubert'}, -- No need for 2 commands seems to me.
+}
+return T{
+    short_name = 'mg',
+    long_name = 'Mog Garden',
+    npc_plural = 'garden entry npcs',
+    npc_names = npc_names,
+    zone_npc_list = function(type)
+        local mlist = windower.ffxi.get_mob_list()
+        mlist = table.filter(mlist, function(name)
+            return name ~= "" and npc_names[type]:any(string.startswith+{name})
+        end)
+        mlist = table.map(mlist, function(name)
+            return {name=name}
+        end)
+        return mlist
+    end,
+    validate = function(menu_id, zone, current_activity)
+		if not (  menu_id == 575 or menu_id == 1015 or menu_id == 808 or menu_id == 546 or menu_id == 896 or menu_id == 440 ) then
+            return "Incorrect menu detected! Menu ID: "..menu_id
+        end
+        if current_activity.sub_cmd == 'zone' and not entry_zones:contains(zone) then
+            return 'Not in an entry zone!'
+        end
+        return nil
+    end,
+    missing = function(warpdata, zone, p)
+        local missing = T{}
+        return missing
+    end,
+    help_text = "| Mog Garden |\n- mg zone -- Enter Mog Garden from Eastern/Western Adoulin or Mog Dinghy in a Port zone or exit Mog Garden from Mog Dinghy.\n-----------------------------",
+    sub_zone_targets =  S{},
+    auto_select_zone = function(zone)
+    end,
+    auto_select_sub_zone = function(zone)
+    end,
+    build_warp_packets = function(current_activity, zone, p, settings)
+        packet = packets.new('outgoing', 0x05B)
+        packet["Target"] = npc.id
+        packet["Option Index"] = 0
+        packet["_unknown1"] = 16384
+        packet["Target Index"] = npc.index
+        packet["Automated Message"] = false
+        packet["_unknown2"] = 0
+        packet["Zone"] = zone
+        packet["Menu ID"] = menu
+        actions:append(T{packet=packet, description='cancel menu', message='This map is only meant for sub-command.'})
+        return actions
+    end,
+    sub_commands = {
+        zone = function(current_activity, zone, p, settings)
+            local actions = T{}
+            local packet = nil
+            local menu = p["Menu ID"]
+            local npc = current_activity.npc
+            local warpmessage
+            -- update request
+            packet = packets.new('outgoing', 0x016)
+            packet["Target Index"] = windower.ffxi.get_player().index
+            actions:append(T{packet=packet, description='update request'})
+            if zone == 280 then
+                warpmessage='Leaving Mog Garden. Heading back from whence you came.'
+            else
+                warpmessage='Entering Mog Garden.'
+            end
+            packet = packets.new('outgoing', 0x05B)
+            packet["Target"] = npc.id
+            packet["Option Index"] = 1
+            packet["_unknown1"] = 0
+            packet["Target Index"] = npc.index
+            packet["Automated Message"] = false
+            packet["_unknown2"] = 0
+            packet["Zone"] = zone
+            packet["Menu ID"] = menu
+            actions:append(T{packet=packet, expecting_zone=true, delay = wiggle_value(settings.simulated_response_time, settings.simulated_response_variation), description='complete menu', message=warpmessage})  
+
+            return actions
+        end,
+    },
+    warpdata = T{
+
+	},
+}

--- a/map/homepoints.lua
+++ b/map/homepoints.lua
@@ -4,7 +4,6 @@ local npc_names = T{
 }
 -- Which homepoint we go to when we specify a zone, whether in shorthand or longform, and not a sub-zone location. QoL
 -- Others are already the most ideal homepoint for a given zone or there is only one homepoint.
---[[
 local default_by_keyword = {
     jeuno = "1", -- Jeuno zones
     nor = "2", -- Norg AH
@@ -22,7 +21,6 @@ local default_by_keyword = {
     mine = "3", -- Bastok Mines alchemy
     sou = "1", --Southern San d'Oria 1 Sparks, Unity, Voidwatch, Exit, Deeds, Copper Voucher exchange.
 }
-    ]]
 return T{ -- option: 2
     short_name = {'hp','ho'},
     long_name = 'Homepoint',
@@ -70,21 +68,22 @@ return T{ -- option: 2
     end,
     help_text = "| Homepoints |\n Command options [hp, ho]\n- hp zone name [homepoint_number] -- warp to a designated homepoint.\n- hp set -- set the closest homepoint as your return homepoint\n-----------------------------",
     sub_zone_targets = S{'entrance', 'mog house', 'auction house', '1', '2', '3', '4', '5', '6', '7', '8', '9', },
-    --[[
     auto_select_sub_zone = function(zone, specified)
-        local destiny = specified.zone:lower()
-        if not specified.subzone then
-            for keyword, value in pairs(default_by_keyword) do
-                if destiny:find(keyword, 1, true) then
-                    return value
+        if not specified.legacy then
+            local destiny = specified.zone:lower()
+            if not specified.subzone then
+                for keyword, value in pairs(default_by_keyword) do
+                    if destiny:find(keyword, 1, true) then
+                        return value
+                    end
                 end
+            else
+                return nil
             end
-            return "ah"
         else
             return nil
         end
     end,
-    ]]
     build_warp_packets = function(current_activity, zone, p, settings)
         local actions = T{}
         local packet = nil

--- a/map/limbus.lua
+++ b/map/limbus.lua
@@ -2,11 +2,11 @@ local settings = nil
 local entry_zones = S{33}
 local limbus_zones = S{37,38}
 local npc_names = T{
-    port = S{'Swirling Vortex','Matter Diffusion Module'},
-    ['next'] = S{'Swirling Vortex','Matter Diffusion Module'},
-	['random'] = S{'Swirling Vortex','Matter Diffusion Module'},
-	back = S{'Swirling Vortex','Matter Diffusion Module'},
-    warp = S{'Swirling Vortex','Matter Diffusion Module'},
+    port = S{'Swirling Vortex','Matter Diffusion Module','Exit'},
+    ['next'] = S{'Swirling Vortex','Matter Diffusion Module','Exit'},
+	['random'] = S{'Swirling Vortex','Matter Diffusion Module','Exit'},
+	back = S{'Swirling Vortex','Matter Diffusion Module','Exit'},
+    warp = S{'Swirling Vortex','Matter Diffusion Module','Exit'},
     enter = S{'Swirling Vortex'},
     ['exit'] = S{'Radiant Aureole'},
 }
@@ -33,6 +33,7 @@ local npc_names = T{
 	   SE2 = {display_name = 'Southeast 2', zone = 38, menu_id = 119,  index = 688, npc = 16933552, offset = 6, x = 576,z = 0, y = -428.00003051758,  h = 223, unknown1 = 42, unknown2 = 1},
 	   SE3 = {display_name = 'Southeast 3', zone = 38, menu_id = 120,  index = 689, npc = 16933553, offset = 7, x = 428.00003051758,  z = 0, y = -385.00003051758,  h = 159, unknown1 = 43, unknown2 = 1},
 	   SE4 = {display_name = 'Southeast 4', zone = 38, menu_id = 121,  index = 690, npc = 16933554, offset = 8, x = 176.00001525879,  z = 0, y = -628,h = 223, unknown1 = 44, unknown2 = 1},
+	   CN = {display_name = 'Apollyon CN',  zone = 38, menu_id = 123,  index = 691, npc = 16933555, offset = 8, x = 0,  z = 0, y = 196.00001525879,h = 63, unknown1 = 51, unknown2 = 1},
         },
     ['temenos'] ={
        E  = {display_name = 'Entrance' ,        zone = 37, menu_id = 1000, index = 795, npc = 16929563, offset = 1, x = 580, z = 0 ,  y = 86.000007629395,   h = 63,  unknown1 = 1 , unknown2 = 1},
@@ -60,7 +61,8 @@ local npc_names = T{
 	   C1 = {display_name = 'Central Tower 1',  zone = 37, menu_id = 1022, index = 874, npc = 16929642, offset = 5, x = 580, z = -2.3800001144409, y = -544, h = 191, unknown1 = 41, unknown2 = 1},
 	   C2 = {display_name = 'Central Tower 2',  zone = 37, menu_id = 1023, index = 875, npc = 16929643, offset = 6, x = 260, z = -162.38000488281, y = -504.00003051758,  h = 191, unknown1 = 42, unknown2 = 1},
 	   C3 = {display_name = 'Central Tower 3',  zone = 37, menu_id = 1024, index = 876, npc = 16929644, offset = 7, x = 20,  z = -2.3800001144409, y = -544, h = 191, unknown1 = 43, unknown2 = 1},
-	   C4 = {display_name = 'Central Tower 4',  zone = 37, menu_id = 1025, index = 877, npc = 16929645, offset = 8, x = -296,z = -162.38000488281, y = -500.00003051758,  h = 127, unknown1 = 44, unknown2 = 1},    
+	   C4 = {display_name = 'Central Tower 4',  zone = 37, menu_id = 1025, index = 877, npc = 16929645, offset = 8, x = -296,z = -162.38000488281, y = -500.00003051758,  h = 127, unknown1 = 44, unknown2 = 1},
+	   CN = {display_name = 'Temenos CN',       zone = 37, menu_id = 1026, index = 878, npc = 16929646, offset = 8, x = -540,z = -2.3800001144409, y = -584,  h = 191, unknown1 = 51, unknown2 = 1},   
          }
 	}
 
@@ -276,11 +278,23 @@ return T {
 		local destination = nil
 		local cross_tower_checkinator = nil
 		local current_floor_checkinator = nil
+		local CN_check = nil
         if current_activity.sub_cmd == 'port' or current_activity.sub_cmd == 'next' or current_activity.sub_cmd == 'back' or current_activity.sub_cmd == 'random' then
             destination = nil
         else
             destination = current_activity.activity_settings
         end
+		--====== CN ======
+		if destination and (destination.menu_id == 123 or destination.menu_id == 1026) then
+			if menu_id ~= 102 and menu_id ~= 103 and menu_id ~= 1000 then
+				return "You must be at the entrance to warp there."
+			end
+			local unlockerator = p["Menu Parameters"] --and p["Menu Parameters"]:unpack('b8', 1)
+			CN_check = unlockerator and has_bit(unlockerator, 4)
+			if CN_check then
+				return "You cannot enter right now; CN is not open."
+			end
+		end
         --------------------------------------------------------------------------------------------------------------------------------------------
         --  Apollyon
         --------------------------------------------------------------------------------------------------------------------------------------------
@@ -292,7 +306,7 @@ return T {
 		end
 if zone == 38 then
         if not (current_activity.sub_cmd == 'enter' or current_activity.sub_cmd == 'exit') and
-        not (menu_id >= 102 and menu_id <= 121) then
+        not (menu_id >= 102 and menu_id <= 123) then
             return "Incorrect menu detected! Menu ID: " .. menu_id
         end
 		-------------------------------------------------------------------------------------------------------------------------------------------
@@ -348,7 +362,7 @@ if zone == 38 then
 				elseif menu_id == 111 then
 					destination = destination_array.apollyon.SW4
 				end
-			elseif menu_id >= 112 and menu_id <= 121 then
+			elseif menu_id >= 112 and menu_id <= 123 then
 				if menu_id == 112 then
 					destination = destination_array.apollyon.E1
 				elseif menu_id == 113 then
@@ -369,11 +383,15 @@ if zone == 38 then
 					destination = destination_array.apollyon.SE4
 				elseif menu_id == 121 then
 					destination = destination_array.apollyon.E1
+				elseif menu_id == 123 then
+					destination = destination_array.apollyon.E1
 				end
 			end
 		elseif current_activity.sub_cmd == 'back' then
-			if menu_id <= 121 and menu_id >= 113 then
-				if menu_id == 121 then
+			if menu_id <= 123 and menu_id >= 113 then
+				if menu_id == 123 then
+					destination = destination_array.apollyon.E1
+				elseif menu_id == 121 then
 					destination = destination_array.apollyon.SE3
 				elseif menu_id == 120 then
 					destination = destination_array.apollyon.SE2
@@ -456,8 +474,18 @@ if zone == 38 then
 				return 'Cannot warp to other towers from here.'
 			end
         end
-        --------------------------------------------------------------------------------------------------------------------------------------------
-    end    --  Temenos
+		---- CN Cross-tower prevention
+		if menu_id == 123 and destination.menu_id ~= 102 and destination.menu_id ~= 103 then
+			if cross_tower_checkinator then 
+				cross_tower_checkinator = nil
+				destination = destination_array.apollyon.E1
+			else
+				return 'Cannot warp to other towers from here.'
+			end
+		end
+    end 
+		--------------------------------------------------------------------------------------------------------------------------------------------   
+		 --  Temenos
         --------------------------------------------------------------------------------------------------------------------------------------------
 elseif zone == 37 then
 		-------------------------------------------------------------------------------------------------------------------------------------------
@@ -476,7 +504,7 @@ elseif zone == 37 then
 				if menu_id == destination.menu_id then
 					return "Open chest on this floor."
 				end
-			end 
+			end
 		elseif current_activity.sub_cmd == 'random' then
 			if _temenos_shuffle then
 				destination = destination_array.temenos[_temenos_shuffle]
@@ -531,7 +559,7 @@ elseif zone == 37 then
 				elseif menu_id == 1016 then
 					destination = destination_array.temenos.E3
 				end
-			elseif menu_id >= 1017 and menu_id <= 1025 then
+			elseif menu_id >= 1017 and menu_id <= 1026 then
 				if menu_id == 1017 then
 					destination = destination_array.temenos.E4
 				elseif menu_id == 1018 then
@@ -550,11 +578,15 @@ elseif zone == 37 then
 					destination = destination_array.temenos.C4
 				elseif menu_id == 1025 then
 					destination = destination_array.temenos.E
+				elseif menu_id == 1026 then
+					destination = destination_array.temenos.E
 				end
 			end
 		elseif current_activity.sub_cmd == 'back' then
-			if menu_id <= 1025 and menu_id >= 1017 then
-				if menu_id == 1025 then
+			if menu_id <= 1026 and menu_id >= 1017 then
+				if menu_id == 1026 then
+					destination = destination_array.temenos.E
+				elseif menu_id == 1025 then
 					destination = destination_array.temenos.C3
 				elseif menu_id == 1024 then
 					destination = destination_array.temenos.C2
@@ -615,7 +647,7 @@ elseif zone == 37 then
 		end
 -------------------------------------------
         if not
-        (menu_id >= 1000 and menu_id <= 1025) then
+        (menu_id >= 1000 and menu_id <= 1026) then
             return "Incorrect menu detected! Menu ID: " .. menu_id
         end
         -- prevent warping between towers / next command cross-tower destination entrance override
@@ -648,13 +680,22 @@ elseif zone == 37 then
         end
         ----------------Central Tower--------------------------------------------------------------------------
         if (menu_id >= 1022 and menu_id <= 1025) and destination.menu_id ~= 1000 and (destination.menu_id > 1025 or destination.menu_id < 1022) then
-			if cross_tower_checkinator then 
+			if cross_tower_checkinator then
 				cross_tower_checkinator = nil
 				destination = destination_array.temenos.E
 			else
 				return 'Cannot warp to other towers from here.'
 			end
         end
+		----CN Cross-tower prevention----
+		if menu_id == 1026 and destination.menu_id ~= 1000 then
+			if cross_tower_checkinator then
+				cross_tower_checkinator = nil
+				destination = destination_array.temenos.E
+			else
+				return 'Cannot warp to other towers from here.'
+			end
+		end
 end
 	if current_activity.sub_cmd ~= 'exit' and current_activity.sub_cmd ~= 'enter' then
 		------------Same floor prevention / data check warp override------------------
@@ -679,7 +720,7 @@ end
 		return nil
     end,
     help_text = "| Limbus |\n Command options [li, te, ap]\n- li e1/nw1/sw2/ne5/se3   e/n1/w2/e5/c3 etc. -- warp to a designated tower and floor in limbus. \n- li next -- warp to the first uncompleted floor in sequence, if this is in another tower, will warp to the entrance.\n- li random -- Similar to the next command, sends you to floors you do not have the data for until you have collected all data; Will send you to other floors within the same tower until all are completed then will send to another tower/floor.\n- li port -- warp to the next floor of any tower, if on last floor will warp to the entrance, if at entrance will warp to first floor of the first tower. \n- li back -- the reverse of port command, teleports to the previous floor. If you are on the first floor of a tower this will send you to the entrance, if you are at the entrance this command will send you to the last floor of the last tower.\n- li enter -- enter apollyon. \n- li exit -- exit apollyon.\n------------------------------",
-    sub_zone_targets = S {'e1', 'e2', 'nw1', 'nw2', 'nw3', 'nw4', 'nw5', 'sw1', 'sw2', 'sw3','sw4', 'ne1', 'ne2', 'ne3', 'ne4', 'ne5', 'se1', 'se2', 'se3', 'se4','entrance','n1', 'n2', 'n3', 'n4', 'n5', 'n6', 'n7', 'w1', 'w2','w3', 'w4', 'w5', 'w6', 'w7', 'e1', 'e2', 'e3', 'e4', 'e5','e6','e7','c1','c2','c3','c4'}, 
+    sub_zone_targets = S {'e1', 'e2', 'nw1', 'nw2', 'nw3', 'nw4', 'nw5', 'sw1', 'sw2', 'sw3','sw4', 'ne1', 'ne2', 'ne3', 'ne4', 'ne5', 'se1', 'se2', 'se3', 'se4','entrance','n1', 'n2', 'n3', 'n4', 'n5', 'n6', 'n7', 'w1', 'w2','w3', 'w4', 'w5', 'w6', 'w7', 'e1', 'e2', 'e3', 'e4', 'e5','e6','e7','c1','c2','c3','c4','cn'}, 
     auto_select_zone = function(zone)
         if zone == 38 then
             return 'apollyon'
@@ -692,15 +733,15 @@ end
         local packet = nil
         local menu = p["Menu ID"]
         local npc = current_activity.npc
-        local destination = current_activity.activity_settings		
-        -- update request
-        packet = packets.new('outgoing', 0x016)
-        packet["Target Index"] = windower.ffxi.get_player().index
-        actions:append(T {
-            packet = packet,
-            description = 'update request'
-        })
+        local destination = current_activity.activity_settings
 
+            -- update request
+            packet = packets.new('outgoing', 0x016)
+            packet["Target Index"] = windower.ffxi.get_player().index
+            actions:append(T {
+                packet = packet,
+                description = 'update request'
+            })
         -- menu change
         packet = packets.new('outgoing', 0x05B)
         packet["Target"] = npc.id
@@ -714,7 +755,7 @@ end
         packet["_unknown2"] = 0
         actions:append(T {
             packet = packet,
-            delay = 0.2,
+            delay = wiggle_value(settings.simulated_response_time, settings.simulated_response_variation),
             description = 'send options'
         })
 
@@ -753,7 +794,7 @@ end
             packet = packet,
             wait_packet = 0x052,
             expecting_zone = false,
-            delay = 1,
+            delay = 2.5,
             description = 'complete menu'
         })
 
@@ -788,7 +829,7 @@ sub_commands = {
 				elseif menu == 111 then
 					destination = destination_array.apollyon.SW4
 				end
-			elseif menu >= 112 and menu <= 121 then
+			elseif menu >= 112 and menu <= 123 then
 				if menu == 112 then
 					destination = destination_array.apollyon.E1
 				elseif menu == 113 then
@@ -808,6 +849,8 @@ sub_commands = {
 				elseif menu == 120 then
 					destination = destination_array.apollyon.SE4
 				elseif menu == 121 then
+					destination = destination_array.apollyon.E1
+				elseif menu == 123 then
 					destination = destination_array.apollyon.E1
 				end
 			end
@@ -854,7 +897,7 @@ sub_commands = {
 				elseif menu == 1017 then
 					destination = destination_array.temenos.E4
 				end
-			elseif menu >= 1018 and menu <= 1025 then
+			elseif menu >= 1018 and menu <= 1026 then
 				if menu == 1018 then
 					destination = destination_array.temenos.E5
 				elseif menu == 1019 then
@@ -871,11 +914,12 @@ sub_commands = {
 					destination = destination_array.temenos.C4
 				elseif menu == 1025 then
 					destination = destination_array.temenos.E
+				elseif menu == 1026 then
+					destination = destination_array.temenos.E
 				end
 			end
 		end
     end
-	
 				if zone ~= destination.zone then
 					log('Woa woa woa.')
 					return
@@ -904,7 +948,7 @@ sub_commands = {
             packet["_unknown2"] = 0
             actions:append(T {
                 packet = packet,
-                delay = 0.2,
+				delay = wiggle_value(settings.simulated_response_time, settings.simulated_response_variation) ,
                 description = 'send options'
             })
 
@@ -944,7 +988,7 @@ sub_commands = {
             packet = packet,
             wait_packet = 0x052,
             expecting_zone = false,
-            delay = 1,
+            delay = 2.5,
             description = 'complete menu'
             })
             return actions
@@ -958,8 +1002,10 @@ sub_commands = {
 		local destination = nil
     if zone == 38 then
 		if current_activity.sub_cmd == 'back' then
-			if menu <= 121 and menu >= 113 then
-				if menu == 121 then
+			if menu <= 123 and menu >= 113 then
+				if menu == 123 then
+					destination = destination_array.apollyon.E1
+				elseif menu == 121 then
 					destination = destination_array.apollyon.SE3
 				elseif menu == 120 then
 					destination = destination_array.apollyon.SE2
@@ -1004,8 +1050,10 @@ sub_commands = {
 		end
     elseif zone == 37 then
 		if current_activity.sub_cmd == 'back' then
-			if menu <= 1025 and menu >= 1017 then
-				if menu == 1025 then
+			if menu <= 1026 and menu >= 1017 then
+				if menu == 1026 then
+					destination = destination_array.temenos.E
+				elseif menu == 1025 then
 					destination = destination_array.temenos.C3
 				elseif menu == 1024 then
 					destination = destination_array.temenos.C2
@@ -1094,7 +1142,7 @@ sub_commands = {
             packet["_unknown2"] = 0
             actions:append(T {
                 packet = packet,
-                delay = 0.2,
+                delay = wiggle_value(settings.simulated_response_time, settings.simulated_response_variation) ,
                 description = 'send options'
             })
 
@@ -1134,7 +1182,7 @@ sub_commands = {
             packet = packet,
             wait_packet = 0x052,
             expecting_zone = false,
-            delay = 1,
+            delay = 2.5,
             description = 'complete menu'
             })
             return actions
@@ -1173,6 +1221,8 @@ sub_commands = {
         ----------------Central Tower--------------------------------------------------------------------------
         elseif (menu >= 118 and menu <= 121) and (destination.menu_id ~= 102 and destination.menu_id ~= 103) and (destination.menu_id > 121 or destination.menu_id < 118) then
 				destination = destination_array.apollyon.E1
+		elseif menu == 123 then
+			destination = destination_array.apollyon.E1 -- If we're in CN we only go to entrance.
         end
     elseif zone == 37 then
 			if _temenos_floor then
@@ -1197,6 +1247,8 @@ sub_commands = {
         ----------------Central Tower--------------------------------------------------------------------------
         elseif (menu >= 1022 and menu <= 1025) and destination.menu_id ~= 1000 and (destination.menu_id > 1025 or destination.menu_id < 1022) then
 				destination = destination_array.temenos.E
+		elseif menu == 1026 then -- If we're in CN we only go to entrance.
+			destination = destination_array.temenos.E
         end
     end
 				if zone ~= destination.zone then
@@ -1230,7 +1282,7 @@ sub_commands = {
             packet["_unknown2"] = 0
             actions:append(T {
                 packet = packet,
-                delay = 0.2,
+                delay = wiggle_value(settings.simulated_response_time, settings.simulated_response_variation) ,
                 description = 'send options'
             })
 
@@ -1270,7 +1322,7 @@ sub_commands = {
             packet = packet,
             wait_packet = 0x052,
             expecting_zone = false,
-            delay = 1,
+            delay = 2.5,
             description = 'complete menu'
             })
             return actions
@@ -1310,6 +1362,8 @@ sub_commands = {
         ----------------Central Tower--------------------------------------------------------------------------
         elseif (menu >= 118 and menu <= 121) and (destination.menu_id ~= 102 and destination.menu_id ~= 103) and (destination.menu_id > 121 or destination.menu_id < 118) then
 				destination = destination_array.apollyon.E1
+		elseif menu == 123 then
+			destination = destination_array.apollyon.E1 -- If we're in CN we only go to entrance.
         end
     elseif zone == 37 then
 			if _temenos_shuffle then
@@ -1334,6 +1388,8 @@ sub_commands = {
         ----------------Central Tower--------------------------------------------------------------------------
         elseif (menu >= 1022 and menu <= 1025) and destination.menu_id ~= 1000 and (destination.menu_id > 1025 or destination.menu_id < 1022) then
 				destination = destination_array.temenos.E
+		elseif menu == 1026 then -- If we're in CN we only go to entrance.
+			destination = destination_array.temenos.E
         end
 		if menu == destination.menu_id then
 				destination = destination_array.temenos.E
@@ -1371,7 +1427,7 @@ sub_commands = {
             packet["_unknown2"] = 0
             actions:append(T {
                 packet = packet,
-                delay = 0.2,
+                delay = wiggle_value(settings.simulated_response_time, settings.simulated_response_variation) ,
                 description = 'send options'
             })
 
@@ -1411,7 +1467,7 @@ sub_commands = {
             packet = packet,
             wait_packet = 0x052,
             expecting_zone = false,
-            delay = 1,
+            delay = 2.5,
             description = 'complete menu'
             })
             return actions
@@ -1448,7 +1504,7 @@ sub_commands = {
             packet["_unknown2"] = 0
             packet["Zone"] = zone
             packet["Menu ID"] = menu
-            actions:append(T{packet=packet, wait_packet=0x052, expecting_zone=true, delay=1+wiggle_value(settings.simulated_response_time, settings.simulated_response_variation), description='complete menu'})
+            actions:append(T{packet=packet, wait_packet=0x052, expecting_zone=true, delay = 1 + wiggle_value(settings.simulated_response_time, settings.simulated_response_variation), description='complete menu'})
 
             return actions
         end,
@@ -1485,7 +1541,7 @@ sub_commands = {
             packet["_unknown2"] = 0
             packet["Zone"] = zone
             packet["Menu ID"] = menu
-            actions:append(T{packet=packet, wait_packet=0x052, expecting_zone=true, delay=1+wiggle_value(settings.simulated_response_time, settings.simulated_response_variation), description='complete menu'})
+            actions:append(T{packet=packet, wait_packet=0x052, expecting_zone=true, delay = 1 +  wiggle_value(settings.simulated_response_time, settings.simulated_response_variation), description='complete menu'})
 
             return actions
         end,
@@ -1493,8 +1549,8 @@ sub_commands = {
     warpdata = T{
         ['Apollyon'] = T{
 			   ['Entrance']  = { shortcut = 'E1' },
-               ['E1'] = {display_name = 'Entrance 1', zone = 38,  menu_id = 102, index = 671, npc = 16933535, offset = 1, x = -608,z = 0, y = -600,h = 126, unknown1 = 1,unknown2 = 1},
-			   ['E2'] = {display_name = 'Entrance 2', zone = 38, menu_id = 103, index = 672, npc = 16933536, offset = 1, x = 608, z = 0, y = -600,h = 0,unknown1 = 1,  unknown2 = 1},
+               ['E1'] = {display_name = 'Entrance 1',   zone = 38, menu_id = 102, index = 671, npc = 16933535, offset = 1, x = -608,z = 0, y = -600,h = 126, unknown1 = 1,unknown2 = 1},
+			   ['E2'] = {display_name = 'Entrance 2',   zone = 38, menu_id = 103, index = 672, npc = 16933536, offset = 1, x = 608, z = 0, y = -600,h = 0,unknown1 = 1,  unknown2 = 1},
 			   ['NW1'] = {display_name = 'Northwest 1', zone = 38, menu_id = 104, index = 673, npc = 16933537, offset = 1, x = -440.00003051758, z = 0, y = -88.000007629395, h = 191, unknown1 = 11, unknown2 = 1},
 			   ['NW2'] = {display_name = 'Northwest 2', zone = 38, menu_id = 105, index = 674, npc = 16933538, offset = 2, x = -534,z = 0, y = 171.00001525879,h = 159, unknown1 = 12, unknown2 = 1},
 			   ['NW3'] = {display_name = 'Northwest 3', zone = 38, menu_id = 106, index = 675, npc = 16933540, offset = 3, x = -294,z = 0, y = 171.00001525879,h = 159, unknown1 = 13, unknown2 = 1},
@@ -1513,9 +1569,10 @@ sub_commands = {
 			   ['SE2'] = {display_name = 'Southeast 2', zone = 38, menu_id = 119, index = 688, npc = 16933552, offset = 6, x = 576,z = 0, y = -428.00003051758, h = 223, unknown1 = 42, unknown2 = 1},
 			   ['SE3'] = {display_name = 'Southeast 3', zone = 38, menu_id = 120, index = 689, npc = 16933553, offset = 7, x = 428.00003051758,  z = 0, y = -385.00003051758, h = 159, unknown1 = 43, unknown2 = 1},
 			   ['SE4'] = {display_name = 'Southeast 4', zone = 38, menu_id = 121, index = 690, npc = 16933554, offset = 8, x = 176.00001525879,  z = 0, y = -628,h = 223, unknown1 = 44, unknown2 = 1},
+			   ['CN'] = {display_name = 'Apollyon CN',  zone = 38, menu_id = 123, index = 691, npc = 16933555, offset = 8, x = 0,  z = 0, y = 196.00001525879,h = 63, unknown1 = 51, unknown2 = 1},
 		},
         ['Temenos'] = T{  
-			   ['Entrance']  = {display_name = 'Entrance' , zone = 37,  menu_id = 1000, index = 795, npc = 16929563, offset = 1, x = 580, z = 0 ,y = 86.000007629395,h = 63,unknown1 = 1 , unknown2 = 1},
+			   ['Entrance']  = {display_name = 'Entrance' , zone = 37, menu_id = 1000, index = 795, npc = 16929563, offset = 1, x = 580, z = 0 ,y = 86.000007629395,h = 63,unknown1 = 1 , unknown2 = 1},
 			   ['N1'] = {display_name = 'Northern Tower 1', zone = 37, menu_id = 1001, index = 853, npc = 16929621, offset = 1, x = 380.00003051758,z = 71.620002746582 ,y = 376.00003051758,h = 191,unknown1 = 11,unknown2 = 1},
 			   ['N2'] = {display_name = 'Northern Tower 2', zone = 37, menu_id = 1002, index = 854, npc = 16929622, offset = 2, x = 180.00001525879,z = -82.380004882812,y = 376.00003051758,h = 191,unknown1 = 12,unknown2 = 1},
 			   ['N3'] = {display_name = 'Northern Tower 3', zone = 37, menu_id = 1003, index = 855, npc = 16929623, offset = 3, x = 60.000003814697,z = 71.620002746582 ,y = 376.00003051758,h = 191,unknown1 = 13,unknown2 = 1},
@@ -1541,6 +1598,7 @@ sub_commands = {
 			   ['C2'] = {display_name = 'Central Tower 2',  zone = 37, menu_id = 1023, index = 875, npc = 16929643, offset = 6, x = 260, z = -162.38000488281, y = -504.00003051758,h = 191, unknown1 = 42, unknown2 = 1},
 			   ['C3'] = {display_name = 'Central Tower 3',  zone = 37, menu_id = 1024, index = 876, npc = 16929644, offset = 7, x = 20,  z = -2.3800001144409, y = -544, h = 191, unknown1 = 43, unknown2 = 1},
 			   ['C4'] = {display_name = 'Central Tower 4',  zone = 37, menu_id = 1025, index = 877, npc = 16929645, offset = 8, x = -296,z = -162.38000488281, y = -500.00003051758,h = 127, unknown1 = 44, unknown2 = 1},
+			   ['CN'] = {display_name = 'Temenos CN',       zone = 37, menu_id = 1026, index = 878, npc = 16929645, offset = 8, x = -540,z = -2.3800001144409, y = -584,  h = 191, unknown1 = 51, unknown2 = 1},   
 		},
     },
 }

--- a/map/limbus.lua
+++ b/map/limbus.lua
@@ -1598,7 +1598,7 @@ sub_commands = {
 			   ['C2'] = {display_name = 'Central Tower 2',  zone = 37, menu_id = 1023, index = 875, npc = 16929643, offset = 6, x = 260, z = -162.38000488281, y = -504.00003051758,h = 191, unknown1 = 42, unknown2 = 1},
 			   ['C3'] = {display_name = 'Central Tower 3',  zone = 37, menu_id = 1024, index = 876, npc = 16929644, offset = 7, x = 20,  z = -2.3800001144409, y = -544, h = 191, unknown1 = 43, unknown2 = 1},
 			   ['C4'] = {display_name = 'Central Tower 4',  zone = 37, menu_id = 1025, index = 877, npc = 16929645, offset = 8, x = -296,z = -162.38000488281, y = -500.00003051758,h = 127, unknown1 = 44, unknown2 = 1},
-			   ['CN'] = {display_name = 'Temenos CN',       zone = 37, menu_id = 1026, index = 878, npc = 16929645, offset = 8, x = -540,z = -2.3800001144409, y = -584,  h = 191, unknown1 = 51, unknown2 = 1},   
+			   ['CN'] = {display_name = 'Temenos CN',       zone = 37, menu_id = 1026, index = 878, npc = 16929646, offset = 8, x = -540,z = -2.3800001144409, y = -584,  h = 191, unknown1 = 51, unknown2 = 1},   
 		},
     },
 }

--- a/map/maps.lua
+++ b/map/maps.lua
@@ -9,6 +9,7 @@ local maps =  {
     ['portals'] = require('map/portals'),
     ['voidwatch'] = require('map/voidwatch'),
     ['spd'] = require('map/spd'),
+    ['garden'] = require('map/garden'),
     ['sortie'] = require('map/sortie'),
     ['odyssey'] = require('map/odyssey'),
     ['limbus'] = require('map/limbus'),

--- a/map/sortie.lua
+++ b/map/sortie.lua
@@ -9,11 +9,11 @@ local npc_names = T{
     repop = S{'Diaphanous Device','Diaphanous Bitzer'},
 }
 local destination_array = {
-        device_  = {display_name = 'Device' ,         menu_id = 1000, index = 817, zone = zone_tag,npc = 21001009, offset = 1, x = -836.00006103516, y = -20, z = -178.00001525879 , h = 0, unknown1 = 1 , unknown2 = 1},
-        device_a = {display_name = 'Device #A',       menu_id = 1001, index = 818, zone = zone_tag,npc = 21001010, offset = 2, x = -460.00003051758, y = 96.000007629395, z = -150 , h = 63, unknown1 = 2  , unknown2 = 1},
-        device_b = {display_name = 'Device #B',       menu_id = 1002, index = 819, zone = zone_tag,npc = 21001011, offset = 3, x = -344.00003051758, y = -20, z = -150 , h = 127, unknown1 = 3 , unknown2 = 1},
-        device_c = {display_name = 'Device #C',       menu_id = 1003, index = 820, zone = zone_tag,npc = 21001012, offset = 4, x = -460.00003051758, y = -136, z = -150 , h = 191, unknown1 = 4 , unknown2 = 1},
-        device_d = {display_name = 'Device #D',       menu_id = 1004, index = 821, zone = zone_tag,npc = 21001013, offset = 5, x = -576, y = -20, z = -150 , h = 0, unknown1 = 5, unknown2 = 1},
+        device_  = {display_name = 'Device' ,         menu_id = 1000, index = 817, zone = zone_tag,npc = 21001009, offset = 32, x = -836.00006103516, y = -20, z = -178.00001525879 , h = 0, unknown1 = 1 , unknown2 = 1},
+        device_a = {display_name = 'Device #A',       menu_id = 1001, index = 818, zone = zone_tag,npc = 21001010, offset = 33, x = -460.00003051758, y = 96.000007629395, z = -150 , h = 63, unknown1 = 2  , unknown2 = 1},
+        device_b = {display_name = 'Device #B',       menu_id = 1002, index = 819, zone = zone_tag,npc = 21001011, offset = 34, x = -344.00003051758, y = -20, z = -150 , h = 127, unknown1 = 3 , unknown2 = 1},
+        device_c = {display_name = 'Device #C',       menu_id = 1003, index = 820, zone = zone_tag,npc = 21001012, offset = 35, x = -460.00003051758, y = -136, z = -150 , h = 191, unknown1 = 4 , unknown2 = 1},
+        device_d = {display_name = 'Device #D',       menu_id = 1004, index = 821, zone = zone_tag,npc = 21001013, offset = 36, x = -576, y = -20, z = -150 , h = 0, unknown1 = 5, unknown2 = 1},
         gadget_a = {display_name = 'Gadget #A',       menu_id = 1005, index = 822, zone = zone_tag,npc = 21001014, offset = 1, x = -900.00006103516, y = 416.00003051758, z = -200.00001525879 , h = 63, unknown1 = 1, unknown2 = 1},
         gadget_b = {display_name = 'Gadget #B',       menu_id = 1006, index = 823, zone = zone_tag,npc = 21001015, offset = 2, x = -24.000001907349, y = 420.00003051758, z = -200.00001525879 , h = 127, unknown1 = 2, unknown2 = 1},
         gadget_c = {display_name = 'Gadget #C',       menu_id = 1007, index = 824, zone = zone_tag,npc = 21001016, offset = 3, x = -20, y = -456.00003051758, z = -200.00001525879 , h = 191, unknown1 = 3, unknown2 = 1},
@@ -163,15 +163,26 @@ return T {
             destination = nil
         else
             destination = current_activity.activity_settings
+            ---- Device unlocks -----
+            local unlock_bits = p["Menu Parameters"]
+            local destination_locked = true
+            if destination.offset ~= nil then
+                destination_locked = has_bit(unlock_bits, destination.offset)
+            end
+            if menu_id == destination.menu_id then
+                return "You're already at that location"
+            elseif destination_locked then
+                return "Cannot warp to "..destination.key.." without the Ra'Kaznar Plate #"..destination.key.." KI."
+            end
+            ------------------------
         end
 		if origination == nil or bitcheckinator == nil then
 			return 'Please update your superwarp.lua file to the latest version for Sortie support'
 		end
-		-------------------------------------------------------------------------------------------------------------------------------------------
        -- Destination setters
         --------------------------------------------------------------------------------------------------------------------------------------------
     if current_activity.sub_cmd ~= 'repop' then
-        if menu_id == 1010 then
+        if menu_id == 1010 then 
             destination = destination_array.bitzer_e
         elseif menu_id == 1011 then
             destination = destination_array.bitzer_f
@@ -266,80 +277,6 @@ return T {
             return 'Not in a Sortie zone!'
         end
         --------------------------------------------------------------------------------------------------------------------
-        ----   KI CHECKS. DO NOT JACK AROUND WITH THIS! IT WONT WORK ANYWAY: CONFIRMED. CHEERS ----
-
-        -- Bitzers --
-        if (menu_id >= 1010 and menu_id <= 1017) then
-            if menu_id == 1010 and not has_temp_item(temp_item_ids.Sheet.A) then
-                return 'You do not have the Ra\'Kaznar Sheet #A'
-            end
-            if menu_id == 1011 and not has_temp_item(temp_item_ids.Sheet.B) then
-                return 'You do not have the Ra\'Kaznar Sheet #B'
-            end
-            if menu_id == 1012 and not has_temp_item(temp_item_ids.Sheet.C) then
-                return 'You do not have the Ra\'Kaznar Sheet #C'
-            end
-            if menu_id == 1013 and not has_temp_item(temp_item_ids.Sheet.D) then
-                return 'You do not have the Ra\'Kaznar Sheet #D'
-            end
-
-        -- Gadgets --
-        elseif (menu_id >= 1005 and menu_id <= 1008) or (menu_id >= 1018 and menu_id <= 1021) then
-            if menu_id == 1005 and not has_temp_item(temp_item_ids.Shard.A) then
-                return 'You do not have the Ra\'Kaznar Shard #A'
-            end
-            if menu_id == 1006 and not has_temp_item(temp_item_ids.Shard.B) then
-                return 'You do not have the Ra\'Kaznar Shard #B'
-            end
-            if menu_id == 1007 and not has_temp_item(temp_item_ids.Shard.C) then
-                return 'You do not have the Ra\'Kaznar Shard #C'
-            end
-            if menu_id == 1008 and not has_temp_item(temp_item_ids.Shard.D) then
-                return 'You do not have the Ra\'Kaznar Shard #D'
-            end
-            if menu_id == 1018 and not has_temp_item(temp_item_ids.Shard.E) then
-                return 'You do not have the Ra\'Kaznar Shard #E'
-            end
-            if menu_id == 1019 and not has_temp_item(temp_item_ids.Shard.F) then
-                return 'You do not have the Ra\'Kaznar Shard #F'
-            end
-            if menu_id == 1020 and not has_temp_item(temp_item_ids.Shard.G) then
-                return 'You do not have the Ra\'Kaznar Shard #G'
-            end
-            if menu_id == 1021 and not has_temp_item(temp_item_ids.Shard.H) then
-                return 'You do not have the Ra\'Kaznar Shard #H'
-            end
-
-        -- Devices--
-        elseif (menu_id >= 1000 and menu_id <= 1004) then
-            if menu_id == 1000 and
-                (not has_temp_item(temp_item_ids.Plate.A) and not has_temp_item(temp_item_ids.Plate.B) and
-                    not has_temp_item(temp_item_ids.Plate.C) and not has_temp_item(temp_item_ids.Plate.D)) then
-                return 'You do not have any of the Ra\'Kaznar Plates'
-            end
-            if (menu_id >= 1000 and menu_id <= 1004) and destination.menu_id == 1001 and
-                not has_temp_item(temp_item_ids.Plate.A) then
-                return 'You do not have the Ra\'Kaznar Plate #A'
-            end
-            if (menu_id >= 1000 and menu_id <= 1004) and destination.menu_id == 1002 and
-                not has_temp_item(temp_item_ids.Plate.B) then
-                return 'You do not have the Ra\'Kaznar Plate #B'
-            end
-            if (menu_id >= 1000 and menu_id <= 1004) and destination.menu_id == 1003 and
-                not has_temp_item(temp_item_ids.Plate.C) then
-                return 'You do not have the Ra\'Kaznar Plate #C'
-            end
-            if (menu_id >= 1000 and menu_id <= 1004) and destination.menu_id == 1004 and
-                not has_temp_item(temp_item_ids.Plate.D) then
-                return 'You do not have the Ra\'Kaznar Plate #D'
-            end
-        end
-        -- Fragments--
-        if menu_id == 1022 and
-            (not has_temp_item(temp_item_ids.Fragment.A) or not has_temp_item(temp_item_ids.Fragment.B) or
-                not has_temp_item(temp_item_ids.Fragment.C) or not has_temp_item(temp_item_ids.Fragment.D)) then
-            return 'You do not have all 4 Ra\'Kaznar Fragments'
-        end
     end
         return nil
     end,
@@ -960,11 +897,11 @@ return T {
                 ['#B'] = { shortcut = 'B' },
                 ['#C'] = { shortcut = 'C' },
                 ['#D'] = { shortcut = 'D' },
-  --[[Device]]  ['S'] =   { menu_id = 1000, index = 817, zone = 275,npc = 21001009, offset = 1, x = -836.00006103516, y = -20, z = -178.00001525879 , h = 0, unknown1 = 1 , unknown2 = 1},
-  --[[Device A]]['A'] =   { menu_id = 1001, index = 818, zone = 275,npc = 21001010, offset = 2, x = -460.00003051758, y = 96.000007629395, z = -150 , h = 63, unknown1 = 2  , unknown2 = 1},
-  --[[Device B]]['B'] =   { menu_id = 1002, index = 819, zone = 275,npc = 21001011, offset = 3, x = -344.00003051758, y = -20, z = -150 , h = 127, unknown1 = 3 , unknown2 = 1},
-  --[[Device C]]['C'] =   { menu_id = 1003, index = 820, zone = 275,npc = 21001012, offset = 4, x = -460.00003051758, y = -136, z = -150 , h = 191, unknown1 = 4 , unknown2 = 1},
-  --[[Device D]]['D'] =   { menu_id = 1004, index = 821, zone = 275,npc = 21001013, offset = 5, x = -576, y = -20, z = -150 , h = 0, unknown1 = 5, unknown2 = 1}, 
+  --[[Device]]  ['S'] =   { menu_id = 1000, index = 817, zone = 275,npc = 21001009, offset = 32, x = -836.00006103516, y = -20, z = -178.00001525879 , h = 0, unknown1 = 1 , unknown2 = 1},
+  --[[Device A]]['A'] =   { menu_id = 1001, index = 818, zone = 275,npc = 21001010, offset = 33, x = -460.00003051758, y = 96.000007629395, z = -150 , h = 63, unknown1 = 2  , unknown2 = 1},
+  --[[Device B]]['B'] =   { menu_id = 1002, index = 819, zone = 275,npc = 21001011, offset = 34, x = -344.00003051758, y = -20, z = -150 , h = 127, unknown1 = 3 , unknown2 = 1},
+  --[[Device C]]['C'] =   { menu_id = 1003, index = 820, zone = 275,npc = 21001012, offset = 35, x = -460.00003051758, y = -136, z = -150 , h = 191, unknown1 = 4 , unknown2 = 1},
+  --[[Device D]]['D'] =   { menu_id = 1004, index = 821, zone = 275,npc = 21001013, offset = 36, x = -576, y = -20, z = -150 , h = 0, unknown1 = 5, unknown2 = 1}, 
 		},
         --[[
 		            ['Outer Ra\'Kaznar [U2]'] = T{

--- a/sendall.lua
+++ b/sendall.lua
@@ -14,7 +14,7 @@ local status_box = texts.new({
             padding = 1
         }
 },
-    bg = {alpha = 190, red = 0, green = 65, blue = 90},
+    bg = {alpha = 190, red = 0, green = 75, blue = 95},
     flags = {right = false, bottom = false},
 })
 status_box:hide()
@@ -64,31 +64,6 @@ local function get_missing_players(entry)
         end
     end
     return missing
-end
-
--- =========================
--- Send All
--- =========================
-function send_all(msg, delay, participants)
-    if participants == nil then
-        participants = get_participants()
-    end
-
-    local total_delay = 0
-    local me = get_player_name()
-
-    for _,c in ipairs(participants) do
-        if c == me then
-            receive_send_all:schedule(total_delay, msg)
-        else
-            exec:schedule(total_delay, c, msg)
-        end
-        total_delay = total_delay + delay
-    end
-end
-
-function receive_send_all(msg)
-    print('receive_send_all not overridden! msg: '..msg)
 end
 
 -- =========================
@@ -169,6 +144,49 @@ function get_participants()
     return result
 end
 
+function receive_send_all(msg)
+    print('receive_send_all not overridden! msg: '..msg)
+end
+
+-- =========================
+-- Send All
+-- =========================
+function reset_all(delay, participants)
+    if participants == nil then
+        participants = get_participants()
+    end
+
+    local total_delay = 0
+    local me = get_player_name()
+
+    for _,c in ipairs(participants) do
+        if c == me then
+            reset:schedule(total_delay)
+        else
+            windower.send_ipc_message('reset '..c..' '..total_delay)
+        end
+        total_delay = total_delay + delay
+    end
+end
+
+function send_all(msg, delay, participants)
+    if participants == nil then
+        participants = get_participants()
+    end
+
+    local total_delay = 0
+    local me = get_player_name()
+
+    for _,c in ipairs(participants) do
+        if c == me then
+            receive_send_all:schedule(total_delay, msg)
+        else
+            exec:schedule(total_delay, c, msg)
+        end
+        total_delay = total_delay + delay
+    end
+end
+
 function send_all_with_confirm(msg, delay, participants, on_complete, readout)
     if participants == nil then
         participants = get_participants()
@@ -202,7 +220,7 @@ function send_all_with_confirm(msg, delay, participants, on_complete, readout)
 
     -- start completion watcher
     coroutine.schedule(function()
-        local timeoutinator = os.clock() + 15
+        local timeoutinator = os.clock() + 16
         local complete = true
         while pending_confirms[warp_id] and active_warp_id == warp_id and os.clock() < timeoutinator do
             local entry = pending_confirms[warp_id]
@@ -240,13 +258,16 @@ function send_all_with_confirm(msg, delay, participants, on_complete, readout)
                 active_warp_id = nil
                 break
             end
-            coroutine.sleep(0.05)
+            coroutine.sleep(0.1)
         end
         if not complete then
             local message = table.concat(get_missing_players(pending_confirms[warp_id]), ', ')
-            log('Failed to warp '..message)
+            if #message < 1 then
+                log('Failed to warp.')
+            else
+                log('Failed to warp '..message)
+            end
         end
-        
         status_box:hide()
         pending_confirms = {}
         active_warp_id = nil
@@ -324,6 +345,12 @@ windower.register_event('ipc message', function(msg)
             current_warp_id = warp_id
             -- execute command
             receive_send_all(msg)
+        end
+    elseif cmd == 'reset' then
+        local target = args[1]
+        local delayer = args[2]
+        if player and target == player then
+            reset:schedule(delayer)
         end
     end
 end)

--- a/sendall.lua
+++ b/sendall.lua
@@ -1,21 +1,84 @@
 require('tables')
+local texts = require('texts')
+local screen_w = windower.get_windower_settings().ui_x_res
+local screen_h = windower.get_windower_settings().ui_y_res
+local status_box = texts.new({
+    pos = {x = math.floor(screen_w / 3), y = math.floor(screen_h / 1.75)},
+    text = {font = 'Consolas', size = 10,
+        stroke = {
+            alpha = 255,
+            red = 0,
+            green = 0,
+            blue = 0,
+            width = 1,
+            padding = 1
+        }
+},
+    bg = {alpha = 190, red = 0, green = 65, blue = 90},
+    flags = {right = false, bottom = false},
+})
+status_box:hide()
+-- =========================
+-- Vars
+-- =========================
+local scans = {}
+local scan_counter = 0
+local last_known_count = 1
+local max_timeout = 0.15
+local quiet_time = 0.03
+local pending_confirms = {}
+local active_warp_id = nil
+current_warp_id = nil
+warp_sender = nil
+local spinner_frames = {'|', '/', '-', '\\'}
+local spinner_index = 1
+-- =========================
+-- Helper functionators
+-- =========================
 
+local function get_spinner()
+    local frame = spinner_frames[spinner_index]
+    spinner_index = (spinner_index % #spinner_frames) + 1
+    return frame
+end
+local function get_player_name()
+    local me = windower.ffxi.get_mob_by_target('me')
+    return me and me.name
+end
 
-local participating_characters = nil
+local function make_id()
+    return tostring(os.clock()) .. '_' .. tostring(math.random(1000,9999))
+end
 
 local function exec(participant, msg)
     windower.send_ipc_message('execute '..participant..' '..msg)
 end
 
--- send a message to all 'particiants' with the given delay between them.
+local function get_missing_players(entry)
+    local missing = {}
+    if entry then
+        for _, name in ipairs(entry.expected) do
+            if not entry.received[name] then
+                missing[#missing+1] = name
+            end
+        end
+    end
+    return missing
+end
+
+-- =========================
+-- Send All
+-- =========================
 function send_all(msg, delay, participants)
     if participants == nil then
         participants = get_participants()
     end
 
     local total_delay = 0
+    local me = get_player_name()
+
     for _,c in ipairs(participants) do
-        if c == windower.ffxi.get_mob_by_target('me').name then
+        if c == me then
             receive_send_all:schedule(total_delay, msg)
         else
             exec:schedule(total_delay, c, msg)
@@ -24,47 +87,233 @@ function send_all(msg, delay, participants)
     end
 end
 
--- Function to catch the send-all exec. Handle whatever you need to do in this function. Either in this file, or in the main file.
 function receive_send_all(msg)
     print('receive_send_all not overridden! msg: '..msg)
 end
 
-local function marco()
-    local player = windower.ffxi.get_mob_by_target('me').name
-    participating_characters = T{}
-    participating_characters:append(player)
-    windower.send_ipc_message('marco '..player)
+-- =========================
+-- Scan System
+-- =========================
+local function start_scan()
+    scan_counter = scan_counter + 1
+    local id = scan_counter
+
+    local player = get_player_name()
+    if not player then return nil end
+
+    scans[id] = {
+        participants = {[player] = true}, -- dedup via keys
+        start_time = os.clock(),
+    }
+    
+    windower.send_ipc_message('marco '..player..' '..id)
+    return id
 end
 
--- send an IPC message to all local clients and record which come back.
 function get_participants()
-    marco()
-    coroutine.sleep(0.1)
+    local id = start_scan()
+    if not id then return T{} end
 
-    local r = participating_characters:copy()
-    participating_characters = nil
-    return r
+    if last_known_count >= 7 then quiet_time = 0.06 -- about 6 passes; Increase required time since polo for larger multibox systems.
+    elseif last_known_count <= 6 then quiet_time = 0.03 end --atleast 3 passes.
+    local start = os.clock()
+    local last_increase = os.clock()
+
+    local last_count = 0
+    while os.clock() - start < max_timeout do
+        local scan = scans[id]
+        if not scan then break end
+
+        -- count participants
+        local count = 0
+        for _ in pairs(scan.participants) do
+            count = count + 1
+        end
+
+        -- we detect the increase
+        if count > last_count then
+            last_count = count
+            last_increase = os.clock()
+        end
+
+        -- early return if no new participants for quiet_time
+        if os.clock() - last_increase >= quiet_time then
+            local result = T{}
+            for name,_ in pairs(scan.participants) do
+                result:append(name)
+            end
+
+            last_known_count = math.max(last_known_count, count)
+            scans[id] = nil
+            return result
+        end
+
+        coroutine.sleep(0.01)
+    end
+
+    -- If we experience an unlikely scenario where responses have came in with delay we build the list after max timeout here.
+    local scan = scans[id]
+    local result = T{}
+
+    if scan then
+        local count = 0
+        for name,_ in pairs(scan.participants) do
+            result:append(name)
+            count = count + 1
+        end
+
+        last_known_count = math.max(last_known_count, count)
+        scans[id] = nil
+    end
+
+    return result
 end
 
+function send_all_with_confirm(msg, delay, participants, on_complete, readout)
+    if participants == nil then
+        participants = get_participants()
+    end
+    warp_sender = windower.ffxi.get_mob_by_target('me').name
+    local warp_id = make_id()
+    active_warp_id, current_warp_id = warp_id, warp_id
 
--- handle the ipc messages. 
-windower.register_event('ipc message', function(msg) 
+    pending_confirms[warp_id] = {
+        expected = participants,
+        received = {},
+        callback = on_complete
+    }
+
+    local total_delay = 0
+    local me = get_player_name()
+
+    for _,c in ipairs(participants) do
+        if c == me then
+            coroutine.schedule(function()
+                receive_send_all(msg)
+            end, total_delay)
+        else
+            coroutine.schedule(function()
+                windower.send_ipc_message('execute '..warp_id..' '..c..' '..msg)
+            end, total_delay)
+        end
+
+        total_delay = total_delay + delay
+    end
+
+    -- start completion watcher
+    coroutine.schedule(function()
+        local timeoutinator = os.clock() + 15
+        local complete = true
+        while pending_confirms[warp_id] and active_warp_id == warp_id and os.clock() < timeoutinator do
+            local entry = pending_confirms[warp_id]
+            if readout then
+                local missing = entry and get_missing_players(entry)
+                if #missing > 0 then
+                    status_box:text(
+                    string.format(
+                        ' |superwarp| %s  \n----------------\nWaiting on (%d/%d)\n  %s ',
+                        get_spinner(),
+                        #missing,
+                        #entry.expected,
+                        table.concat(missing, '\n  ')
+                    )
+                    )
+                    status_box:show()
+                else
+                    status_box:hide()
+                end
+            end
+            complete = true
+            for _,name in ipairs(entry.expected) do
+                if not entry.received[name] then
+                    complete = false
+                    break
+                end
+            end
+
+            if complete then
+                if entry.callback then
+                    entry.callback(warp_id, entry)
+                end
+                status_box:hide()
+                pending_confirms[warp_id] = nil
+                active_warp_id = nil
+                break
+            end
+            coroutine.sleep(0.05)
+        end
+        if not complete then
+            local message = table.concat(get_missing_players(pending_confirms[warp_id]), ', ')
+            log('Failed to warp '..message)
+        end
+        
+        status_box:hide()
+        pending_confirms = {}
+        active_warp_id = nil
+    end, 0)
+end
+
+function warp_listener(confirm, player)
+    if confirm and player == warp_sender and pending_confirms[current_warp_id] then
+        local warp_id = current_warp_id
+        local entry = pending_confirms[warp_id]
+        entry.received[player] = true
+    else
+        active_warp_id = make_id()
+        pending_confirms = {}
+    end
+end
+
+windower.register_event('ipc message', function(msg)
     local args = msg:split(' ')
     local cmd = args[1]
     args:remove(1)
-    local player = windower.ffxi.get_mob_by_target('me') and windower.ffxi.get_mob_by_target('me').name
+
+    local player = get_player_name()
 
     if cmd == 'marco' then
-        if player then
-            windower.send_ipc_message('polo '..player)
-        end
-    elseif cmd == 'polo' then
-        if participating_characters ~= nil then 
-            participating_characters:append(args[1])
-        end
-    elseif cmd == 'execute' and args[1] == player then
-        args:remove(1)
-        receive_send_all(args:concat(' '))
+        local sender = args[1]
+        local id = tonumber(args[2])
 
+        if id then
+            if player then
+                windower.send_ipc_message('polo '..player..' '..id)
+            else
+                coroutine.schedule(function()
+                    local retry_player = get_player_name()
+                    if retry_player then
+                        windower.send_ipc_message('polo '..retry_player..' '..id)
+                    end
+                end, 0.1)
+            end
+        end
+
+    elseif cmd == 'polo' then
+        local name = args[1]
+        local id = tonumber(args[2])
+
+        local scan = id and scans[id]
+        if scan and name then
+            scan.participants[name] = true -- dedup safe
+        end
+    elseif cmd == 'confirm' then
+        local warp_id = args[1]
+        local name = args[2]
+        local entry = pending_confirms[warp_id]
+        if entry and name then
+            entry.received[name] = true
+        end
+    elseif cmd == 'execute' then
+        local warp_id = args[1]
+        local target = args[2]
+        if player and target == player then
+            args:remove(1)
+            args:remove(1)
+            local msg = args:concat(' ')
+            warp_sender = nil
+            current_warp_id = warp_id
+            -- execute command
+            receive_send_all(msg)
+        end
     end
 end)

--- a/sendall.lua
+++ b/sendall.lua
@@ -303,6 +303,16 @@ windower.register_event('ipc message', function(msg)
         if entry and name then
             entry.received[name] = true
         end
+    elseif cmd == 'sync_limbus_chests' then
+        local chestdata = args[1]
+        if chestdata then
+            local success, chest_table = pcall(function()
+                return loadstring('return '..chestdata)()
+            end)
+            if success and type(chest_table) == 'table' then
+                sync_chest_data(chest_table)
+            end
+        end
     elseif cmd == 'execute' then
         local warp_id = args[1]
         local target = args[2]

--- a/superwarp.lua
+++ b/superwarp.lua
@@ -45,10 +45,11 @@ _addon.name = 'superwarp'
 
 _addon.author = 'Akaden'
 
-_addon.version = '1.1'
+_addon.version = '1.1.1'
 
 _addon.commands = {'sw','superwarp'}
 
+require('vectors')
 require('tables')
 require('logger')
 require('functions')
@@ -174,18 +175,36 @@ local state = {
 
 local function add_table_entry(zone, entry)
     local t = settings.limbus_chests[zone]
-    if not t then return end
-    if t[entry] == 1 then return end
-    t[entry] = 1
-
-    for k, v in pairs(t) do
-        if k ~= entry then
-            t[k] = v + 1
-            if t[k] > 4 then
-                t[k] = 4
-            end
-        end
+    if not t or not t[entry] then
+        return
     end
+
+    if t[entry] == 1 then
+        return
+    end
+
+    local chests = {}
+
+    for name, rank in pairs(t) do
+        chests[#chests + 1] = {name = name, rank = rank}
+    end
+
+    table.sort(chests, function(a, b)
+        if a.name == entry then
+            return true
+        elseif b.name == entry then
+            return false
+        elseif a.rank ~= b.rank then
+            return a.rank < b.rank
+        else
+            return a.name < b.name
+        end
+    end)
+
+    for i, chest in ipairs(chests) do
+        t[chest.name] = i
+    end
+
     config.save(settings)
 end
 
@@ -263,6 +282,34 @@ local function resolve_shortcuts(t, selection)
     if selection.shortcut == nil then return selection end
 
     return resolve_shortcuts(t, t[selection.shortcut])
+end
+
+local function resolve_waypoint_subzone(map_name, search_term)
+    local best_zone, best_sub_zone, best_score, best_map
+
+    for zone_name, zone_map in pairs(maps[map_name].warpdata) do
+        if type(zone_map) == 'table' and not (zone_map.index or zone_map.shortcut) then
+            local sub_keys = get_keys(zone_map)
+            local sub_name, sub_score = fmatch(search_term, sub_keys)
+
+            if sub_name and sub_score then
+                local sub_zone_map = zone_map[sub_name]
+                if sub_zone_map then
+                    sub_zone_map = resolve_shortcuts(zone_map, sub_zone_map)
+                    if sub_zone_map and sub_zone_map.index then
+                        if not best_score or sub_score > best_score then
+                            best_zone = zone_name
+                            best_sub_zone = sub_name
+                            best_score = sub_score
+                            best_map = sub_zone_map
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    return best_zone, best_sub_zone, best_map, best_score
 end
 
 local function resolve_warp(map_name, zone, sub_zone)
@@ -345,15 +392,28 @@ local function resolve_warp(map_name, zone, sub_zone)
             debug("Found zone settings. No sub-zones defined.")
             return zone_map, closest_zone_name    
         end
+    elseif map_name == 'waypoints' then
+        local subzone_term = zone and zone:match('([^%s]+)$') or zone
+        local global_zone, global_sub_zone, global_map, global_score = resolve_waypoint_subzone(map_name, subzone_term)
+        if global_map and global_score and global_score >= 3 and global_score >= #subzone_term then
+            debug('Global sub-zone search success. Term="'..subzone_term..'", zone="'..global_zone..'", sub-zone="'..global_sub_zone..'", value='..global_score)
+            return global_map, global_zone..' - '..global_sub_zone
+        elseif zone and closest_zone_name then
+            log('Search returned no matches: '..zone)
+            debug('Failed search. Term="'..zone..'", nearest match="'..(closest_zone_name or nil)..'", value='..(closest_zone_value or '-1'))
+        else
+            log('Search returned no matches.')
+            debug('Failed search.')
+        end
     elseif zone and closest_zone_name then
         log('Search returned no matches: '..zone)
         debug('Failed search. Term="'..zone..'", nearest match="'..(closest_zone_name or nil)..'", value='..(closest_zone_value or '-1'))
     else
         log('Search returned no matches.')
         debug('Failed search.')
-    return nil
     end
-end 
+    return nil
+end
 
 function poke_npc(id, index)
     local first_poke = true
@@ -433,15 +493,16 @@ end
 local function find_npc(needles)
     local player = windower.ffxi.get_mob_by_target('me')
     local target_npc, distance, npc_key = nil, nil, nil
-
+    if not player then
+        return nil, nil, nil
+    end
+    local px, py, pz = player.x, player.y, player.z
     for index, npc_data in pairs(needles) do
         local npc = windower.ffxi.get_mob_by_index(index)
         if npc and npc.valid_target then
-            local pos_y = math.abs(npc.y - player.y)
-            local pos_z = math.abs(npc.z - player.z)
-            local pos_x = math.abs(npc.x - player.x)
-            local true_distance = math.sqrt(pos_x^2 + pos_y^2 + pos_z^2)
-            if true_distance < 15 then
+            local diff_vec = V{npc.x - px, npc.y - py, npc.z - pz}
+            local true_distance = diff_vec:length()
+            if true_distance < 25 then
                 if not target_npc or npc.distance < distance then
                     target_npc = npc
                     distance = npc.distance

--- a/superwarp.lua
+++ b/superwarp.lua
@@ -145,8 +145,8 @@ end
 if settings.simulated_response_time > 5 then
     settings.simulated_response_time = 5
 end
-if settings.default_packet_wait_timeout < 1 then
-    settings.default_packet_wait_timeout = 1
+if settings.default_packet_wait_timeout < 3 then
+    settings.default_packet_wait_timeout = 3
 end
 if settings.default_packet_wait_timeout > 10 then
     settings.default_packet_wait_timeout = 10
@@ -166,13 +166,19 @@ if not (maps.abyssea.target_ids and maps.campaign.target_ids and maps.odyssey.al
 else
     smartcheck = true
 end
+local intended_npc = nil
+local warp_ident = nil
 local state = {
+    retry_scheduled = nil,
+    warp_interrupted = nil,
+    warp_confirmed = nil,
     loop_count = nil,
     fast_retry = false,
     debug_stack = T{},
     client_lock = false,
 }
 
+local prev_location = nil
 local function add_table_entry(zone, entry)
     local t = settings.limbus_chests[zone]
     if not t or not t[entry] then
@@ -418,9 +424,14 @@ end
 function poke_npc(id, index)
     local first_poke = true
     local first_retry = true
+    if not intended_npc.id then
+        current_activity.poked_npc_index, intended_npc.index = index, index
+        current_activity.poked_npc_id, intended_npc.id = id, id
+    elseif not current_activity.poked_npc_id then
+        current_activity.poked_npc_index = intended_npc.index
+        current_activity.poked_npc_id = intended_npc.id
+    end
     while id and index and current_activity and not current_activity.caught_poke do
-        current_activity.poked_npc_index = index
-        current_activity.poked_npc_id = id
         if not first_poke then
             if state.loop_count > 0 then
                 state.loop_count = state.loop_count - 1
@@ -540,7 +551,7 @@ local function reset(quiet)
         packet["Zone"]=windower.ffxi.get_info()['zone']
         packet["Menu ID"]=last_menu
         packets.inject(packet)
-        last_activity = activity
+        last_activity = current_activity
         if current_activity then
             current_activity.canceled = true
         end
@@ -550,7 +561,7 @@ local function reset(quiet)
         last_menu = nil
 
         if not quiet then
-            log('Should be reset now. Please try again. If still locked, try a second reset.')
+            state.loop_count = 0 -- If we did a cancel / reset command we want to cancel the warp queue.
         end
     else
         general_release()
@@ -559,6 +570,7 @@ local function reset(quiet)
         last_menu = nil
         current_activity = nil
         if not quiet then
+            state.loop_count = 0 -- If we did a cancel / reset command we want to cancel the warp queue.
             log('No warp scheduled.')
         end
     end
@@ -623,7 +635,7 @@ local function do_warp(map_name, zone, sub_zone)
             log("You are already at "..display_name.."! Teleport canceled.")
             state.loop_count = 0
         elseif npc.id and npc.index then
-            current_activity = {type=map_name, npc=npc, activity_settings=warp_settings, zone=zone, sub_zone=sub_zone}
+            current_activity = {type=map_name, npc=npc, activity_settings=warp_settings, zone=zone, sub_zone=sub_zone, warp_ident = warp_ident}
             handle_before_warp()
             log('Warping via ' .. npc.name .. ' to '..display_name..'.')
             timing.warp_init_time = os.clock()
@@ -635,6 +647,7 @@ local function do_warp(map_name, zone, sub_zone)
             poke_npc(npc.id, npc.index)
         end
     else
+        timing.warp_cmd_time = nil
         state.loop_count = 0
     end
 end
@@ -664,7 +677,7 @@ local function do_sub_cmd(map_name, sub_cmd, args)
             timing.warp_cmd_time = nil
         end
     elseif npc and npc.id and npc.index and dist <= 6^2 then
-        current_activity = {type=map_name, sub_cmd=sub_cmd, args=args, npc=npc}
+        current_activity = {type=map_name, sub_cmd=sub_cmd, args=args, npc=npc, warp_ident = warp_ident}
         handle_before_warp()
         timing.warp_init_time = os.clock()
         if timing.warp_cmd_time then
@@ -703,7 +716,7 @@ local function do_find_missing_destinations(map_name, args)
         if #args > 0 then
             max_results = tonumber(args[1]) or 999999 
         end
-        current_activity = {type=map_name, find_missing=true, missing_max=max_results, args=args, npc=npc}
+        current_activity = {type=map_name, find_missing=true, missing_max=max_results, args=args, npc=npc, warp_ident = warp_ident}
         timing.warp_init_time = os.clock()
         if timing.warp_cmd_time then
             debug("Warp initialization time: "..string.format("%.3f", timing.warp_init_time - timing.warp_cmd_time).." seconds")
@@ -828,12 +841,17 @@ local function handle_warp(warp, args, fast_retry, retries_remaining)
 end
 
 local function received_warp_command(cmd, args)
+    local player = windower.ffxi.get_mob_by_target('me')
+    prev_location = {x = player.x, y = player.y, z = player.z}
+    warp_ident = ((warp_ident and warp_ident) or 0) + 1
     if not timing.warp_cmd_time then
         timing.warp_cmd_time = os.clock()
     end
     if current_activity ~= nil then
         log('Superwarp is currently busy. To cancel the last request try "//sw cancel"')
     else
+        intended_npc = {}
+        state.warp_confirmed = false
         if not smartcmd then
             state.debug_stack = T{}
         end
@@ -1155,6 +1173,72 @@ function receive_send_all(msg)
     end
 end
 
+local function auto_shutdown(id) -- Ensure that if the same process ID is still open after a reasonable amount of time after the indicator has been triggered, it gets shut down and systems reset.
+    if current_activity and current_activity.warp_ident == id then
+        debug("The warp has not finished or progressed since the NPC interaction anomoly and superwarp detects no new warp IDs. Resetting..")
+        state.loop_count = 0
+        last_activity = current_activity
+        current_activity = nil
+        reset(true)
+    end
+end
+
+local function read_warp_state(i,id)
+    if current_activity and id ~= current_activity.warp_ident then
+        debug("A different warp has commenced now, leaving it to its own devices.")
+        return
+    elseif current_activity and current_activity.action_index ~= i then
+        debug("Warp state has progressed, leaving it to its own devices.")
+        return
+    elseif not current_activity then
+        debug("No current activity, nothing needs reset.")
+        return
+    end
+    auto_shutdown:schedule(5, id)
+end
+
+local function movement_confirm(menu_confirm)
+    if state.warp_interrupted then
+        local player = windower.ffxi.get_mob_by_target('me')
+        local diff_vector = V{prev_location.x - player.x, prev_location.y - player.y, prev_location.z - player.z}
+        local has_moved = diff_vector:length() >= 25
+        if has_moved then
+            if not state.warp_confirmed then
+                debug("Detected an interrupted warp, confirming the warp with complete menu.")
+                log("Detected an interrupted warp, now confirming. Floor data progress bar should appear.")
+                packets.inject(menu_confirm.packet)
+                state.warp_interrupted = false
+                state.warp_confirmed = true
+                state.loop_count = 0
+                if current_activity then
+                    last_activity = current_activity
+                end
+                current_activity = nil
+                return true
+            end
+            return true
+        else
+            return false
+        end
+    end
+end
+
+local function limbus_state_reader(executor)
+    if executor then
+        local limbus_warp_retainer = current_activity.action_queue[4]
+        --print("Scheduling position check for 5s.")
+        movement_confirm:schedule(5, limbus_warp_retainer)
+    else
+        if current_activity.action_index == 1 then
+            --print("Resetting our flags, a new warp sequence has started in earnest.")
+            state.warp_interrupted = false
+        elseif current_activity.action_index == 4 then
+            --print("Confirmed Warp")
+            state.warp_confirmed = true
+        end
+    end
+end
+
 local function perform_next_action()
     if current_activity and current_activity.running and current_activity.action_queue and current_activity.action_index > 0 then
         local current_action = current_activity.action_queue[current_activity.action_index]
@@ -1181,28 +1265,38 @@ local function perform_next_action()
                 current_action.timeout = settings.default_packet_wait_timeout
             end
             local fn = function(s, ca, i, p, d)
+                if state.retry_scheduled then
+                    state.retry_scheduled = false
+                end
                 if ca and ca.action_index == i and not ca.canceled then
                     debug("timed out waiting for packet 0x"..p:hex().." for action "..tostring(i)..' '..(d or ''))
-
                     if s.loop_count > 0 then
                         reset(true)
                         log("Timed out waiting for response from the menu. Retrying...")
-                        handle_warp:schedule(settings.retry_delay, s.current_warp, s.current_args, false, s.loop_count - 1)
+                        handle_warp:schedule(settings.retry_delay, s.current_warp, s.current_args, false, s.loop_count - 0.2)
                     else
                         reset(true)
                         log("Timed out waiting for response from the menu.")
                     end
                 end
             end
-
-            fn:schedule(current_action.timeout, state, current_activity, current_activity.action_index, current_action.wait_packet, current_action.description)
+            if not state.retry_scheduled then  -- Only allow one fn() call to be scheduled at a time. Increase accountability.
+                state.retry_scheduled = true
+                fn:schedule(current_action.timeout, state, current_activity, current_activity.action_index, current_action.wait_packet, current_action.description)
+            end
         elseif not state.fast_retry and current_action.delay and current_action.delay > 0 then
             debug("delaying action "..tostring(current_activity.action_index)..' '..(current_action.description or '')..' for '.. current_action.delay..'s...')
             local delay_seconds = current_action.delay
             current_action.delay = nil
             last_action = current_action
             perform_next_action:schedule(delay_seconds)
+            if in_limbus_zone and current_activity.action_index == 4 then  -- Often when limbus warps have gotten to this point and then get interrupted from being attacked the warp can still go through leading to missing data bar for that floor. Handle these cases by scheduling a check.
+                limbus_state_reader(true)
+            end
         elseif current_action.packet then
+            if in_limbus_zone then  --Simple flag check to gate further checks, no further checks outside of limbus.
+                limbus_state_reader()
+            end
             -- just a packet, inject it.
             debug("injecting packet "..tostring(current_activity.action_index)..' '..(current_action.description or ''))
             packets.inject(current_action.packet)
@@ -1233,6 +1327,7 @@ local function perform_next_action()
         end
     end
 end
+
 -- Handle menu interraction. 
 windower.register_event('incoming chunk',function(id,data,modified,injected,blocked)
     if current_activity and current_activity.action_queue and current_activity.running then
@@ -1306,10 +1401,12 @@ windower.register_event('incoming chunk',function(id,data,modified,injected,bloc
             if state.loop_count > 0 then
                 if settings.enable_fast_retry_on_interrupt then
                     log("Detected event-skip. Retrying (fast)...")
-                    handle_warp:schedule(0.1, state.current_warp, state.current_args, true, state.loop_count - 1)
+                    state.warp_interrupted = true
+                    handle_warp:schedule(0.1, state.current_warp, state.current_args, true, state.loop_count - 0.2)
                 else
                     log("Detected event-skip. Retrying...")
-                    handle_warp:schedule(0.1, state.current_warp, state.current_args, false, state.loop_count - 1)
+                    state.warp_interrupted = true
+                    handle_warp:schedule(0.1, state.current_warp, state.current_args, false, state.loop_count - 0.2)
                 end
             end
         end
@@ -1320,24 +1417,30 @@ windower.register_event('incoming chunk',function(id,data,modified,injected,bloc
         
         if current_activity and not current_activity.running then
             current_activity.caught_poke = true
-            timing.poke_response_time = os.clock()
-            debug("Response time: "..string.format("%.2f", timing.poke_response_time - timing.poke_time).." seconds")
+            if timing.poke_time then
+                timing.poke_response_time = os.clock()
+                debug("Response time: "..string.format("%.2f", timing.poke_response_time - timing.poke_time).." seconds")
+            else
+                debug("Poke time nil.")
+            end
             timing.poke_response_time = nil
             local zone = windower.ffxi.get_info()['zone']
             local map = maps[current_activity.type]
-
-            if current_activity.poked_npc_id ~= p["NPC"] or current_activity.poked_npc_index ~= p["NPC Index"] then
-                log("Incorrect npc detected. Canceling action.")
-                last_activity = current_activity
-                state.loop_count = 0
-                current_activity = nil
-                return false
-            end
-
+            
             last_menu = p["Menu ID"]
             last_npc = p["NPC"]
             last_npc_index = p["NPC Index"]
+
             --debug("recorded reset params: "..last_menu.." "..last_npc)
+
+            if current_activity.poked_npc_id ~= p["NPC"] or current_activity.poked_npc_index ~= p["NPC Index"] then
+                log("This is not the NPC the warp was meant for. Shutting it down.")
+                last_activity = current_activity
+                state.loop_count = 0
+                current_activity = nil
+                reset:schedule(0.5, true)
+                return true
+            end
 
             if current_activity.find_missing then
                 debug("Finding missing destinations")
@@ -1404,6 +1507,13 @@ windower.register_event('incoming chunk',function(id,data,modified,injected,bloc
                 current_activity = nil
                 return false
             end
+        elseif current_activity then
+            print("Prevented menu from blocking warp, will automatically end this warp sequence if it has gone stale.")
+            debug("Prevented menu from blocking packet exchanges, reading state machine...")
+            local i = current_activity and current_activity.action_index
+            local ident = current_activity.warp_ident -- Capture Warp ID now and check in 5 seconds to determine whether a reset is needed.  (State machine accountability improvement)
+            read_warp_state:schedule(5, i, ident)
+            return true
         end
     end
 end)
@@ -1492,8 +1602,10 @@ windower.register_event('outgoing chunk',function(id,data,modified,injected,bloc
 end)
 windower.register_event('load', function()
     if not settings.understood then
-        windower.add_to_chat(207,'\n Now use sw in place of  hp, wp, sg, un, so, li, ew, ab etc -  for all warp commands!!\n The new smart-command is "//sw" by itself. It autohandles all warp scenarios where a destination need not be specified. i.e. so port or ab enter. It works as any subcommand for any map except others where multiple are usable, in those cases it always serves as one. i.e. next cmd for limbus.')
+        windower.add_to_chat(207,'\n Welcome to superwarp 1.1.1. Now use sw in place of  hp, wp, sg, un, so, li, ew, ab etc -  for all warp commands!!\n The new smart-command is "//sw" by itself. It autohandles all warp scenarios where a destination need not be specified. i.e. so port or ab enter. It works as any subcommand for any map except others where multiple are usable, in those cases it always serves as one. i.e. next cmd for limbus.')
         windower.add_to_chat(207,' All legacy functionality is unchanged.')
+        windower.add_to_chat(207,' The interrupt/retry system has been re-tooled to make it more focused and intentional. It is no longer possible to have an additional warp go through from a single command when attacked and interrupted during warp procedure. (No more basement re-entries in Sortie.) Limbus warp interrupts can no longer result in missing data bars.')
+        windower.add_to_chat(207,' sw help to list all information.')
         windower.add_to_chat(207,' sw understood to stop displaying these messages on load.')
     end
     windower.add_to_chat(207,' sw help to list all information.')

--- a/superwarp.lua
+++ b/superwarp.lua
@@ -216,6 +216,33 @@ local function add_table_entry(zone, entry)
     config.save(settings)
 end
 
+local function set_chest_order(data)
+    data = data:lower()
+    local zone, tower
+    if data:find("nw", 1, true) then
+        zone, tower = "apollyon" , "NW5"
+    elseif data:find("sw", 1, true) then
+        zone, tower = "apollyon" , "SW4"
+    elseif data:find("ne", 1, true) then
+        zone, tower = "apollyon" , "NE5"
+    elseif data:find("se", 1, true) then
+        zone, tower = "apollyon" , "SE4"
+    elseif data:find("n", 1, true) then
+        zone, tower = "temenos" , "N7"
+    elseif data:find("w", 1, true) then
+        zone, tower = "temenos" , "W7"
+    elseif data:find("e", 1, true) then
+        zone, tower = "temenos" , "E7"
+    elseif data:find("c", 1, true) then
+        zone, tower = "temenos" , "C4"
+    else
+        log("Invalid argument, chest order tracking not updated.")
+        return
+    end
+    log("Chest tracking updated. "..tower.." stored as most recently opened chest in "..zone..".")
+    add_table_entry(zone, tower)
+end
+
 function log(msg)
     if settings.chat_log_use == 'log' or settings.debug then
         windower.add_to_chat(207, 'superwarp: '..msg)
@@ -755,7 +782,7 @@ local function handle_warp(warp, args, fast_retry, retries_remaining, current_su
         state.loop_count = retries_remaining
     end
     state.fast_retry = fast_retry
-
+    state.warp_interrupted = false
     -- make args safe to index
     if args:length() == 0 then
         -- no args provided; make an empty string so :lower() calls won't error
@@ -867,7 +894,6 @@ local function received_warp_command(cmd, args)
     else
         intended_npc = {}
         state.warp_confirmed = false
-        state.warp_interrupted = false
         state.current_sub_cmd = nil
         if not smartcmd then
             state.debug_stack = T{}
@@ -933,6 +959,14 @@ local function magic_map()
         distance = nil,
         npc = nil,
     }
+
+    local player = windower.ffxi.get_mob_by_target('me')
+    if not player then
+        return best
+    end
+
+    local px, py, pz = player.x, player.y, player.z
+
     local zone_check = windower.ffxi.get_info().zone
     local max_dist = 36
 
@@ -968,15 +1002,26 @@ local function magic_map()
                         local npc = windower.ffxi.get_mob_by_index(index)
 
                         if npc and npc.valid_target then
-                            if not best.distance or npc.distance < best.distance then
-                                best.map_name = last_cache.map_name
-                                best.interaction = interaction_type
-                                best.distance = npc.distance
-                                best.npc = npc
+                            local diff_vec = V{
+                                npc.x - px,
+                                npc.y - py,
+                                npc.z - pz
+                            }
+
+                            local true_distance = diff_vec:length()
+
+                            if true_distance < 25 then  --2D distance checks are squared, these are not.
+                                if not best.distance or npc.distance < best.distance then
+                                    best.map_name = last_cache.map_name
+                                    best.interaction = interaction_type
+                                    best.distance = npc.distance
+                                    best.npc = npc
+                                end
                             end
                         end
                     end
-                    -- if within 6 yalms our work is done
+
+                    -- if within range our work is done
                     if best.npc and best.distance and best.distance < max_dist then
                         last_cache.zone = zone_check
                         last_cache.map_name = best.map_name
@@ -987,8 +1032,8 @@ local function magic_map()
             end
         end
     end
-
-    --   full scan if cache doesn't do the trick
+    
+    -- full scan if cache doesn't do the trick
     for map_name, map in pairs(maps) do
         if map.zone_npc_list and map.npc_names then
             local warp_zones = not map.all_warp_zones
@@ -1002,19 +1047,29 @@ local function magic_map()
                         local npc = windower.ffxi.get_mob_by_index(index)
 
                         if npc and npc.valid_target then
-                            if not best.distance or npc.distance < best.distance then
-                                best.map_name = map_name
-                                best.interaction = interaction_type
-                                best.distance = npc.distance
-                                best.npc = npc
-                            end
+                            local diff_vec = V{
+                                npc.x - px,
+                                npc.y - py,
+                                npc.z - pz
+                            }
 
-                            -- if within 6 yalms our work is done
-                            if best.distance and best.distance < max_dist then
-                                last_cache.zone = zone_check
-                                last_cache.map_name = best.map_name
-                                last_cache.interaction = best.interaction
-                                return best
+                            local true_distance = diff_vec:length()
+
+                            if true_distance < 25 then --2D distance checks are squared, these are not.
+                                if not best.distance or npc.distance < best.distance then
+                                    best.map_name = map_name
+                                    best.interaction = interaction_type
+                                    best.distance = npc.distance
+                                    best.npc = npc
+                                end
+
+                                -- if within range our work is done
+                                if best.distance and best.distance < max_dist then
+                                    last_cache.zone = zone_check
+                                    last_cache.map_name = best.map_name
+                                    last_cache.interaction = best.interaction
+                                    return best
+                                end
                             end
                         end
                     end
@@ -1118,17 +1173,28 @@ windower.register_event('addon command', function(...)
             settings:save()
         end
     elseif cmd == 'chest' then
-        local zone_name = resources.zones[windower.ffxi.get_info().zone].name:lower()
-        if zone_name == 'apollyon' or zone_name == 'temenos' then
-            for k, v in pairs (settings.limbus_chests[zone_name]) do
-                if v == 4 then
-                    log("Open chest at "..k)
-                    break
-                end
-            end
+        if args[1] then
+            set_chest_order(args[1])
         else
-            log('You are not in limbus.')
+            local zone_name = resources.zones[windower.ffxi.get_info().zone].name:lower()
+            if zone_name == 'apollyon' or zone_name == 'temenos' then
+                for k, v in pairs (settings.limbus_chests[zone_name]) do
+                    if v == 4 then
+                        log("Open chest at "..k)
+                        break
+                    end
+                end
+            else
+                log('You are not in limbus.')
+            end
         end
+    elseif cmd and cmd:contains('sync') then
+        local chestdata = T(settings.limbus_chests):tovstring()
+        chestdata = chestdata:gsub('%s+', '')
+        windower.send_ipc_message(
+            'sync_limbus_chests '..chestdata
+        )
+        log('Sent limbus chest sync.')
     elseif cmd and cmd:contains('default') then
         if settings.hp_legacy_defaults then
             settings.hp_legacy_defaults = false
@@ -1162,7 +1228,7 @@ windower.register_event('addon command', function(...)
             local map = maps[key]
             windower.add_to_chat(207,map.help_text)
         end
-        windower.add_to_chat(207,'| superwarp |\nsw cancel -- Cancels pending warp command.\nsw reset -- Attempts to clear menu lock.\nsw chest -- Displays the next chest open location within limbus.\nsw hpdefaults -- Toggles homepoint default destinations between Legacy and New.\nsw display -- Toggles all / party warp display.\nsw missing -- Display destinations you are missing from the nearest warp system if applicable.\n-----------------------------')
+        windower.add_to_chat(207,'| superwarp |\nsw cancel -- Cancels pending warp command.\nsw reset -- Attempts to clear menu lock.\nsw sync -- Instantly synchronizes all characters Limbus chest tracking order with the character the command is executed from.\nsw chest (tower) / chest -- Manually updates chest tracking with the tower you input after the chest command. i.e. //sw chest se; If no argument is provided will display the next chest open location within limbus. i.e. //sw chest\nsw hpdefaults -- Toggles homepoint default destinations between Legacy and New.\nsw display -- Toggles all / party warp display.\nsw missing -- Display destinations you are missing from the nearest warp system if applicable.\n-----------------------------')
         windower.add_to_chat(207,'Use [all/a/@all/party/p] after the command prefix and before the destination to warp all characters or all party/alliance members. (//li p next)\nYou may still use [warp] if you learned to include it or still have macros written this way. (sw hp warp eastern adoulin 1) (Legacy support)\n\n[New!] You may now use "//sw" or "/console sw" for all maps with no extra command prefix. i.e. //sw port , or //sw rab to go to Rabao #2')
         windower.add_to_chat(207,'[New!] superwarp (smartcommand) - You may now use just //sw with no command for all warps that do not require a destination to be specified. i.e. enter and exit commands for abyssea, escha zones and apollyon, domain invasion enter, next command in limbus, port in odyssey and sortie, runic portal assault and return, campaign npcs return and Cavernous Maw port, all 4 Walk Of Echoes commands. It can also be used to go to the default destination in cases that call for specification. "//sw p" to use the smart command with all party members, or "a" for all. Use with confidence. Layers of failsafes are in place.')
     elseif current_activity ~= nil then
@@ -1230,6 +1296,12 @@ local function auto_shutdown(id) -- Ensure that if the same process ID is still 
         current_activity = nil
         reset(true)
     end
+end
+
+function sync_chest_data(chestdata)
+    settings.limbus_chests = chestdata
+    config.save(settings)
+    log('Limbus chest data synced.')
 end
 
 local function read_warp_state(i,id)

--- a/superwarp.lua
+++ b/superwarp.lua
@@ -929,6 +929,12 @@ local function smart_command(best, short_name)
         elseif best.map_name == 'limbus' and zone_check ~= 33 then
             best.interaction = 'next'
         end
+    elseif best.interaction == 'exit' then
+        if best.npc.name:find('Maw', 1, true) then
+            if maps.abyssea.entry_zones:contains(zone_check) then
+                best.interaction = 'enter'
+            end
+        end
     elseif best.map_name == 'limbus' and best.interaction ~= 'exit' then
         if zone_check == 33 then
             best.interaction = 'enter'
@@ -1098,6 +1104,12 @@ local function magic_map()
     end
 
     if best.map_name then
+        if best.map_name == 'campaign' and best.interaction == 'port' then
+            if maps.abyssea.target_ids:contains(best.npc.id) then
+                best.map_name = 'abyssea'
+                best.interaction = 'enter'
+            end
+        end
         last_cache.zone = zone_check
         last_cache.map_name = best.map_name
         last_cache.interaction = best.interaction
@@ -1127,7 +1139,6 @@ local function the_superwarp(genArgs, dispatcher, retries)
         return
     end
     state.debug_stack = T{}
-    debug('Using '..result.npc.name..' for '..result.map_name..'.')
     state.loop_count = nil
     local map = maps[result.map_name]
 
@@ -1142,9 +1153,11 @@ local function the_superwarp(genArgs, dispatcher, retries)
         local smart_cmd
         smart_cmd, short_name = smart_command(result, short_name)
         if smart_cmd ~= 'warp' and short_name ~= 'hp' then
-            debug('No sub-command provided, using '..smart_cmd..'.')
+            debug('No sub-command provided, using '..short_name..' '..smart_cmd..'.')
             genArgs:append(smart_cmd)
         end
+    else
+        debug('Using '..result.npc.name..' for '..result.map_name..'.')
     end
     if dispatcher then genArgs:insert(1, dispatcher) end
     smartcmd = true
@@ -1163,24 +1176,10 @@ windower.register_event('addon command', function(...)
     if cmd and warp_list:contains(cmd:lower()) and args[1] then
         warp_listener()
         received_warp_command(cmd, args)
-    elseif cmd == 'cancel' or cmd == 'reset' then
-        if args[1] then
-            local all = S{'all','a','@all'}:contains(args[1]:lower())
-            local party = S{'party','p','@party'}:contains(args[1]:lower())
-            if all or party then 
-                local participants = nil
-                participants = get_participants()
-                if party then
-                    participants = get_party_members(participants)
-                end
-                participants = order_participants(participants)
-                reset_all(settings.send_all_delay, participants)
-                warp_listener()
-            else
-                reset()
-            end
-        else
-            reset()
+    elseif cmd == 'reset' or cmd == 'cancel' then
+        reset()    
+        if args[1] and args[1]:lower() == 'all' then
+            windower.send_ipc_message('reset')
         end
     elseif cmd == 'debug' then
         settings.debug = not settings.debug

--- a/superwarp.lua
+++ b/superwarp.lua
@@ -1104,12 +1104,6 @@ local function magic_map()
     end
 
     if best.map_name then
-        if best.map_name == 'campaign' and best.interaction == 'port' then
-            if maps.abyssea.target_ids:contains(best.npc.id) then
-                best.map_name = 'abyssea'
-                best.interaction = 'enter'
-            end
-        end
         last_cache.zone = zone_check
         last_cache.map_name = best.map_name
         last_cache.interaction = best.interaction
@@ -1140,6 +1134,12 @@ local function the_superwarp(genArgs, dispatcher, retries)
     end
     state.debug_stack = T{}
     state.loop_count = nil
+    if result.map_name == 'campaign' and result.interaction == 'port' then
+        if maps.abyssea.target_ids:contains(result.npc.id) then
+            result.map_name = 'abyssea'
+            result.interaction = 'enter'
+        end
+    end
     local map = maps[result.map_name]
 
     local short_name
@@ -1176,10 +1176,24 @@ windower.register_event('addon command', function(...)
     if cmd and warp_list:contains(cmd:lower()) and args[1] then
         warp_listener()
         received_warp_command(cmd, args)
-    elseif cmd == 'reset' or cmd == 'cancel' then
-        reset()    
-        if args[1] and args[1]:lower() == 'all' then
-            windower.send_ipc_message('reset')
+    elseif cmd == 'cancel' or cmd == 'reset' then
+        if args[1] then
+            local all = S{'all','a','@all'}:contains(args[1]:lower())
+            local party = S{'party','p','@party'}:contains(args[1]:lower())
+            if all or party then 
+                local participants = nil
+                participants = get_participants()
+                if party then
+                    participants = get_party_members(participants)
+                end
+                participants = order_participants(participants)
+                reset_all(settings.send_all_delay, participants)
+                warp_listener()
+            else
+                reset()
+            end
+        else
+            reset()
         end
     elseif cmd == 'debug' then
         settings.debug = not settings.debug
@@ -1377,7 +1391,7 @@ local function limbus_state_reader(executor)
         movement_confirm:schedule(8, false, limbus_warp_retainer)
     else
         local phase = current_activity.action_index
-        if not phase == 4 then -- Early exit for 1 2 and 3
+        if phase ~= 4 then -- Early exit for 1 2 and 3
             return false
         elseif phase == 4 then
             if not movement_confirm(true) then

--- a/superwarp.lua
+++ b/superwarp.lua
@@ -45,7 +45,7 @@ _addon.name = 'superwarp'
 
 _addon.author = 'Akaden'
 
-_addon.version = '1.1.1'
+_addon.version = '1.1.1+'
 
 _addon.commands = {'sw','superwarp'}
 
@@ -109,10 +109,10 @@ local defaults = {
     hp_legacy_defaults = true,
     limbus_chests = {
         temenos = {
-            ["N7"] = 2,["W7"] = 3,["E7"] = 4,["C4"] = 1
+            ["N7"] = 4,["W7"] = 3,["E7"] = 2,["C4"] = 1
     },
         apollyon = {
-            ["NW5"] = 1,["SW4"] = 2,["NE5"] = 3,["SE4"] = 4
+            ["NW5"] = 4,["SW4"] = 3,["NE5"] = 2,["SE4"] = 1
         },
     }
 }
@@ -181,6 +181,7 @@ local state = {
 }
 
 local prev_location = nil
+local confirm_msg = ''
 local function add_table_entry(zone, entry)
     local t = settings.limbus_chests[zone]
     if not t or not t[entry] then
@@ -241,6 +242,12 @@ local function set_chest_order(data)
     end
     log("Chest tracking updated. "..tower.." stored as most recently opened chest in "..zone..".")
     add_table_entry(zone, tower)
+end
+
+function sync_chest_data(chestdata)
+    settings.limbus_chests = chestdata
+    config.save(settings)
+    log('Limbus chest data synced.')
 end
 
 function log(msg)
@@ -564,7 +571,7 @@ function release(menu_id)
 
 end
 
-local function reset(quiet)
+function reset(quiet)
 	client_lock()
     if last_npc ~= nil and last_menu ~= nil then
         general_release()
@@ -663,6 +670,13 @@ local function do_warp(map_name, zone, sub_zone)
             end
         elseif npc_key and (warp_settings.key == npc_key or npc_key == '1' and not warp_settings.key and warp_settings.npc == npc.index) and warp_settings.zone == windower.ffxi.get_info()['zone'] then
             log("You are already at "..display_name.."! Teleport canceled.")
+            local player = windower.ffxi.get_mob_by_target('me')
+            if player.name == warp_sender then
+                confirm_msg = 'All warps finished.'
+                warp_listener(true, player.name)
+            elseif current_warp_id then
+                windower.send_ipc_message('confirm '..current_warp_id..' '..player.name)
+            end
             state.loop_count = 0
         elseif npc.id and npc.index then
             current_activity = {type=map_name, npc=npc, activity_settings=warp_settings, zone=zone, sub_zone=sub_zone, warp_ident = warp_ident}
@@ -806,12 +820,13 @@ local function handle_warp(warp, args, fast_retry, retries_remaining, current_su
         end
         participants = order_participants(participants)
         debug('sending warp to all: '..participants:concat(', '))
+        confirm_msg = 'All warps confirmed.'
         send_all_with_confirm(
             warp..' '..args:concat(' '),
             settings.send_all_delay,
             participants,
             function(warp_id, entry)
-                log('All warps confirmed.')
+                log(confirm_msg)
             end,
             settings.send_all_display
         )
@@ -915,7 +930,11 @@ local function smart_command(best, short_name)
             best.interaction = 'next'
         end
     elseif best.map_name == 'limbus' and best.interaction ~= 'exit' then
-        best.interaction = 'next'
+        if zone_check == 33 then
+            best.interaction = 'enter'
+        else
+            best.interaction = 'next'
+        end
     elseif best.map_name == 'sortie' then
         if best.npc.name:find('Device', 1, true) then
             best.interaction = 'warp'
@@ -1092,9 +1111,7 @@ end
 local function the_superwarp(genArgs, dispatcher, retries)
 
     if retries == nil then
-        state.loop_count = 4
-    else
-        state.loop_count = retries
+        state.loop_count = settings.max_retries
     end
 
     local result = magic_map()
@@ -1147,15 +1164,23 @@ windower.register_event('addon command', function(...)
         warp_listener()
         received_warp_command(cmd, args)
     elseif cmd == 'cancel' or cmd == 'reset' then
-        reset()
-        if args[1] and args[1]:lower() == 'all' then
-            windower.send_ipc_message('reset')
-        end
-
-    elseif cmd == 'reset' then
-        reset()    
-        if args[1] and args[1]:lower() == 'all' then
-            windower.send_ipc_message('reset')
+        if args[1] then
+            local all = S{'all','a','@all'}:contains(args[1]:lower())
+            local party = S{'party','p','@party'}:contains(args[1]:lower())
+            if all or party then 
+                local participants = nil
+                participants = get_participants()
+                if party then
+                    participants = get_party_members(participants)
+                end
+                participants = order_participants(participants)
+                reset_all(settings.send_all_delay, participants)
+                warp_listener()
+            else
+                reset()
+            end
+        else
+            reset()
         end
     elseif cmd == 'debug' then
         settings.debug = not settings.debug
@@ -1298,12 +1323,6 @@ local function auto_shutdown(id) -- Ensure that if the same process ID is still 
     end
 end
 
-function sync_chest_data(chestdata)
-    settings.limbus_chests = chestdata
-    config.save(settings)
-    log('Limbus chest data synced.')
-end
-
 local function read_warp_state(i,id)
     if current_activity and id ~= current_activity.warp_ident then
         debug("A different warp has commenced now, leaving it to its own devices.")
@@ -1359,10 +1378,7 @@ local function limbus_state_reader(executor)
         movement_confirm:schedule(8, false, limbus_warp_retainer)
     else
         local phase = current_activity.action_index
-        if phase == 1 then
-            state.warp_interrupted = false
-            return false
-        elseif not phase == 4 then -- Early exit for 2 and 3
+        if not phase == 4 then -- Early exit for 1 2 and 3
             return false
         elseif phase == 4 then
             if not movement_confirm(true) then
@@ -1644,6 +1660,15 @@ windower.register_event('incoming chunk',function(id,data,modified,injected,bloc
             if map.validate then validation_message = map.validate(p["Menu ID"], zone, current_activity, p, settings) end
             if validation_message ~= nil then
                 log("WARNING: "..validation_message.." Canceling action.")
+                ------------------Warp Confirm----------------------
+                local player = windower.ffxi.get_mob_by_target('me')
+                if player.name == warp_sender then
+                    confirm_msg = 'All warps finished.'
+                    warp_listener(true, player.name)
+                elseif current_warp_id then
+                    windower.send_ipc_message('confirm '..current_warp_id..' '..player.name)
+                end
+                ---------------------------------------------
                 last_activity = current_activity
                 state.loop_count = 0
                 current_activity = nil

--- a/superwarp.lua
+++ b/superwarp.lua
@@ -11,7 +11,7 @@ modification, are permitted provided that the following conditions are met:
     * Redistributions in binary form must reproduce the above copyright
       notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
-    * Neither the name of Superwarp nor the
+    * Neither the name of superwarp nor the
       names of its contributors may be used to endorse or promote products
       derived from this software without specific prior written permission.
 
@@ -29,7 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ]]
 
 --[[
-    Special thanks to those that have helped with specific areas of Superwarp: 
+    Special thanks to those that have helped with specific areas of superwarp: 
         Waypoint currency calculations: Ivaar, Thorny
         Same-Zone warp data collection: Kenshi
         Escha domain elvorseal packets: Ivaar
@@ -87,12 +87,12 @@ sub_zone_aliases = {
 
 local defaults = {
     debug = false,
-    send_all_delay = 0.3,                   -- delay (seconds) between each character
+    send_all_delay = 0.237,                 -- delay (seconds) between each character
     max_retries = 6,                        -- max retries for loading NPCs.
     retry_delay = 2,                        -- delay (seconds) between retries
     simulated_response_time = 0,            -- response time (seconds) for selecting a single menu item. Note this can happen multiple times per warp.
     simulated_response_variation = 0,       -- random variation (seconds) from the base simulated_response_time in either direction (+ or -)
-    default_packet_wait_timeout = 4,        -- timeout (seconds) for waiting on a packet response before continuing on.
+    default_packet_wait_timeout = 3,        -- timeout (seconds) for waiting on a packet response before continuing on.
     enable_same_zone_teleport = true,       -- enable teleporting between points in the same zone. This is the default behavior in-game. Turning it off will look different than teleporting manually.
     enable_fast_retry_on_interrupt = false, -- after an event skip event, attempt a fast-retry that doesn't wait for packets or delay.
     use_tabs_at_survival_guides = false,    -- use tabs instead of gil at survival guides.
@@ -103,8 +103,10 @@ local defaults = {
     target_npc = true,                      -- locally target the warp/subcommand npc.
     simulate_client_lock = false,           -- lock the local client during a warp/subcommand, simulating menu behavior.
     send_all_order_mode = 'melast',         -- order modes: melast, mefirst, alphabetical
+    send_all_display = true,
     chat_log_use = 'log',                   -- log messages to 'log', 'console', or 'none'. If debug is on, it will always log to the chat log
     understood = false,
+    hp_legacy_defaults = true,
     limbus_chests = {
         temenos = {
             ["N7"] = 2,["W7"] = 3,["E7"] = 4,["C4"] = 1
@@ -145,11 +147,11 @@ end
 if settings.simulated_response_time > 5 then
     settings.simulated_response_time = 5
 end
-if settings.default_packet_wait_timeout < 3 then
-    settings.default_packet_wait_timeout = 3
+if settings.default_packet_wait_timeout < 2 then
+    settings.default_packet_wait_timeout = 2
 end
-if settings.default_packet_wait_timeout > 10 then
-    settings.default_packet_wait_timeout = 10
+if settings.default_packet_wait_timeout > 4 then
+    settings.default_packet_wait_timeout = 4
 end
 config.save(settings)
 local current_zone = windower.ffxi.get_info().zone
@@ -169,7 +171,7 @@ end
 local intended_npc = nil
 local warp_ident = nil
 local state = {
-    retry_scheduled = nil,
+    current_sub_cmd = nil,
     warp_interrupted = nil,
     warp_confirmed = nil,
     loop_count = nil,
@@ -242,7 +244,7 @@ local function get_keys(t)
     return keys
 end
 
-local function order_participants(participants)
+function order_participants(participants)
     local player = windower.ffxi.get_player().name
     if settings.send_all_order_mode ~= 'alphabetical' then
         participants:delete(player)
@@ -265,7 +267,6 @@ local function get_party_members(local_members)
             end
         end
     end
-
     return members
 end
 
@@ -562,6 +563,7 @@ local function reset(quiet)
 
         if not quiet then
             state.loop_count = 0 -- If we did a cancel / reset command we want to cancel the warp queue.
+            log('No warp scheduled.')
         end
     else
         general_release()
@@ -586,7 +588,8 @@ local function handle_before_warp()
         debug('running command before warp: '..settings.command_before_warp)
         windower.send_command(settings.command_before_warp)
     end
-    if (settings.target_npc or settings.simulate_client_lock) and current_activity and current_activity.npc then
+    -- Since the 1/5 of a second makes our retries take longer after being interrupted we autoskip this while being attacked.
+    if not state.warp_interrupted and (settings.target_npc or settings.simulate_client_lock) and current_activity and current_activity.npc then
     	set_target(current_activity.npc.index)
     	coroutine.sleep(0.2) -- give target time to work.
     end
@@ -678,6 +681,9 @@ local function do_sub_cmd(map_name, sub_cmd, args)
         end
     elseif npc and npc.id and npc.index and dist <= 6^2 then
         current_activity = {type=map_name, sub_cmd=sub_cmd, args=args, npc=npc, warp_ident = warp_ident}
+        if current_activity.sub_cmd then
+            state.current_sub_cmd = current_activity.sub_cmd
+        end
         handle_before_warp()
         timing.warp_init_time = os.clock()
         if timing.warp_cmd_time then
@@ -741,8 +747,7 @@ local function handle_map_short_name(map, name)
     return false
 end
 
-local function handle_warp(warp, args, fast_retry, retries_remaining)
-
+local function handle_warp(warp, args, fast_retry, retries_remaining, current_sub_cmd)
     warp = warp:lower()
     if retries_remaining == nil then
         state.loop_count = settings.max_retries
@@ -774,11 +779,20 @@ local function handle_warp(warp, args, fast_retry, retries_remaining)
         end
         participants = order_participants(participants)
         debug('sending warp to all: '..participants:concat(', '))
-
-        send_all(warp..' '..args:concat(' '), settings.send_all_delay, participants)
+        send_all_with_confirm(
+            warp..' '..args:concat(' '),
+            settings.send_all_delay,
+            participants,
+            function(warp_id, entry)
+                log('All warps confirmed.')
+            end,
+            settings.send_all_display
+        )
+        --send_all(warp..' '..args:concat(' '), settings.send_all_delay, participants)
 
         return
     end
+    warp_ident = ((warp_ident and warp_ident) or 0) + 1
     smartcmd = false
     if args[1] and args[1]:lower() == 'missing' then
         args:remove(1)         
@@ -792,7 +806,7 @@ local function handle_warp(warp, args, fast_retry, retries_remaining)
     end
     state.current_warp = warp
     state.current_args = args:copy()
-
+    
     for key,map in pairs(maps) do
         if handle_map_short_name(map, warp) then
             local sub_cmd = nil
@@ -803,8 +817,10 @@ local function handle_warp(warp, args, fast_retry, retries_remaining)
                     end
                 end
             end
-
-            if sub_cmd then
+            if current_sub_cmd then
+                do_sub_cmd(key, current_sub_cmd, args)
+                return
+            elseif sub_cmd then
                 args:remove(1)
                 do_sub_cmd(key, sub_cmd, args)
                 return
@@ -826,7 +842,7 @@ local function handle_warp(warp, args, fast_retry, retries_remaining)
                 if map.auto_select_zone and map.auto_select_zone(zone) then
                     zone_target = map.auto_select_zone(zone)
                 end
-                local specified = {zone = zone_target, subzone = sub_zone_target}
+                local specified = {zone = zone_target, subzone = sub_zone_target, legacy = settings.hp_legacy_defaults}
                 if map.auto_select_sub_zone and map.auto_select_sub_zone(zone, specified) then
                     sub_zone_target = map.auto_select_sub_zone(zone, specified)
                 end
@@ -843,15 +859,16 @@ end
 local function received_warp_command(cmd, args)
     local player = windower.ffxi.get_mob_by_target('me')
     prev_location = {x = player.x, y = player.y, z = player.z}
-    warp_ident = ((warp_ident and warp_ident) or 0) + 1
     if not timing.warp_cmd_time then
         timing.warp_cmd_time = os.clock()
     end
     if current_activity ~= nil then
-        log('Superwarp is currently busy. To cancel the last request try "//sw cancel"')
+        log('superwarp is currently busy. To cancel the last request try "//sw cancel"')
     else
         intended_npc = {}
         state.warp_confirmed = false
+        state.warp_interrupted = false
+        state.current_sub_cmd = nil
         if not smartcmd then
             state.debug_stack = T{}
         end
@@ -1015,7 +1032,7 @@ local function magic_map()
     return best
 end
 ---------------------------------------------
---            [The Superwarp™]             --
+--            [The superwarp™]             --
 ---------------------------------------------
 local function the_superwarp(genArgs, dispatcher, retries)
 
@@ -1059,6 +1076,7 @@ local function the_superwarp(genArgs, dispatcher, retries)
     end
     if dispatcher then genArgs:insert(1, dispatcher) end
     smartcmd = true
+    warp_listener()
     received_warp_command(short_name, genArgs)
 end
 
@@ -1071,8 +1089,9 @@ windower.register_event('addon command', function(...)
     local item = table.concat(args," "):lower()
 
     if cmd and warp_list:contains(cmd:lower()) and args[1] then
+        warp_listener()
         received_warp_command(cmd, args)
-    elseif cmd == 'cancel' then
+    elseif cmd == 'cancel' or cmd == 'reset' then
         reset()
         if args[1] and args[1]:lower() == 'all' then
             windower.send_ipc_message('reset')
@@ -1083,7 +1102,6 @@ windower.register_event('addon command', function(...)
         if args[1] and args[1]:lower() == 'all' then
             windower.send_ipc_message('reset')
         end
-
     elseif cmd == 'debug' then
         settings.debug = not settings.debug
         log('Debug is now '..tostring(settings.debug))
@@ -1099,9 +1117,39 @@ windower.register_event('addon command', function(...)
             settings.understood = true
             settings:save()
         end
+    elseif cmd == 'chest' then
+        local zone_name = resources.zones[windower.ffxi.get_info().zone].name:lower()
+        if zone_name == 'apollyon' or zone_name == 'temenos' then
+            for k, v in pairs (settings.limbus_chests[zone_name]) do
+                if v == 4 then
+                    log("Open chest at "..k)
+                    break
+                end
+            end
+        else
+            log('You are not in limbus.')
+        end
+    elseif cmd and cmd:contains('default') then
+        if settings.hp_legacy_defaults then
+            settings.hp_legacy_defaults = false
+            log('Homepoint defaults set to: New')
+        else
+            settings.hp_legacy_defaults = true
+            log('Homepoint defaults set to: Legacy')
+        end
+        config.save(settings)
+    elseif cmd and cmd:contains('display') then
+        if settings.send_all_display then
+            settings.send_all_display = false
+            log('Sendall readout is now OFF.')
+        else
+            settings.send_all_display = true
+            log('Sendall readout is now ON.')
+        end
+        config.save(settings)
     elseif cmd == 'help' then
         windower.add_to_chat(207,'\n| READ ME |\n[New!] You may now use "//sw" or "/console sw" for all maps with no extra command prefix. i.e. //sw port, or //sw rab to go to Rabao #2')
-        windower.add_to_chat(207,'[New!] Superwarp (smartcommand) - You may now use just //sw with no command for all warps that do not require a destination to be specified. i.e. enter and exit commands for abyssea, escha zones and apollyon, domain invasion enter, next command in limbus, port in odyssey and sortie, runic portal assault and return, campaign npcs return and Cavernous Maw port, all 4 Walk Of Echoes commands. It can also be used to go to the default destination in cases that call for specification. "//sw p" to use the smart command with all party members, or "a" for all. Use with confidence. Layers of failsafes are in place.')
+        windower.add_to_chat(207,'[New!] superwarp (smartcommand) - You may now use just //sw with no command for all warps that do not require a destination to be specified. i.e. enter and exit commands for abyssea, escha zones and apollyon, domain invasion enter, next command in limbus, port in odyssey and sortie, runic portal assault and return, campaign npcs return and Cavernous Maw port, all 4 Walk Of Echoes commands. It can also be used to go to the default destination in cases that call for specification. "//sw p" to use the smart command with all party members, or "a" for all. Use with confidence. Layers of failsafes are in place.')
         windower.add_to_chat(207,'\nUse [all/a/@all/party/p] after the command prefix and before the destination to warp all characters or all party/alliance members. (//li p next)\nYou may still use [warp] if you learned to include it or still have macros written this way. (sw hp warp eastern adoulin 1) (Legacy support)\n-----------------------------')
         local keys = {}
         for key in pairs(maps) do
@@ -1114,11 +1162,11 @@ windower.register_event('addon command', function(...)
             local map = maps[key]
             windower.add_to_chat(207,map.help_text)
         end
-        windower.add_to_chat(207,'| Superwarp |\nsw cancel -- Cancels pending warp command.\nsw reset -- Attempts to clear menu lock.\n-----------------------------')
+        windower.add_to_chat(207,'| superwarp |\nsw cancel -- Cancels pending warp command.\nsw reset -- Attempts to clear menu lock.\nsw chest -- Displays the next chest open location within limbus.\nsw hpdefaults -- Toggles homepoint default destinations between Legacy and New.\nsw display -- Toggles all / party warp display.\nsw missing -- Display destinations you are missing from the nearest warp system if applicable.\n-----------------------------')
         windower.add_to_chat(207,'Use [all/a/@all/party/p] after the command prefix and before the destination to warp all characters or all party/alliance members. (//li p next)\nYou may still use [warp] if you learned to include it or still have macros written this way. (sw hp warp eastern adoulin 1) (Legacy support)\n\n[New!] You may now use "//sw" or "/console sw" for all maps with no extra command prefix. i.e. //sw port , or //sw rab to go to Rabao #2')
-        windower.add_to_chat(207,'[New!] Superwarp (smartcommand) - You may now use just //sw with no command for all warps that do not require a destination to be specified. i.e. enter and exit commands for abyssea, escha zones and apollyon, domain invasion enter, next command in limbus, port in odyssey and sortie, runic portal assault and return, campaign npcs return and Cavernous Maw port, all 4 Walk Of Echoes commands. It can also be used to go to the default destination in cases that call for specification. "//sw p" to use the smart command with all party members, or "a" for all. Use with confidence. Layers of failsafes are in place.')
+        windower.add_to_chat(207,'[New!] superwarp (smartcommand) - You may now use just //sw with no command for all warps that do not require a destination to be specified. i.e. enter and exit commands for abyssea, escha zones and apollyon, domain invasion enter, next command in limbus, port in odyssey and sortie, runic portal assault and return, campaign npcs return and Cavernous Maw port, all 4 Walk Of Echoes commands. It can also be used to go to the default destination in cases that call for specification. "//sw p" to use the smart command with all party members, or "a" for all. Use with confidence. Layers of failsafes are in place.')
     elseif current_activity ~= nil then
-        log('Superwarp is currently busy. To cancel the last request try "//sw cancel"')
+        log('superwarp is currently busy. To cancel the last request try "//sw cancel"')
         return
     else
         timing.warp_cmd_time = os.clock()
@@ -1158,6 +1206,7 @@ windower.register_event('unhandled command', function(cmd, ...)
     local args = T{...}
     for i,v in pairs(args) do args[i]=windower.convert_auto_trans(args[i]) end
     if warp_list:contains(cmd:lower()) then
+        warp_listener()
         received_warp_command(cmd, args)
     end
 end)
@@ -1197,23 +1246,32 @@ local function read_warp_state(i,id)
     auto_shutdown:schedule(5, id)
 end
 
-local function movement_confirm(menu_confirm)
+local function movement_confirm(basic_check, menu_confirm)
+    local player = windower.ffxi.get_mob_by_target('me')
+    local diff_vector = V{prev_location.x - player.x, prev_location.y - player.y, prev_location.z - player.z}
+    local has_moved = diff_vector:length() >= 50
+    if basic_check then
+        if has_moved then
+            return true
+        else
+            return false
+        end
+    end
     if state.warp_interrupted then
-        local player = windower.ffxi.get_mob_by_target('me')
-        local diff_vector = V{prev_location.x - player.x, prev_location.y - player.y, prev_location.z - player.z}
-        local has_moved = diff_vector:length() >= 25
         if has_moved then
             if not state.warp_confirmed then
                 debug("Detected an interrupted warp, confirming the warp with complete menu.")
-                log("Detected an interrupted warp, now confirming. Floor data progress bar should appear.")
                 packets.inject(menu_confirm.packet)
+                last_activity = current_activity
+                current_activity = nil
                 state.warp_interrupted = false
                 state.warp_confirmed = true
                 state.loop_count = 0
-                if current_activity then
-                    last_activity = current_activity
+                if player.name == warp_sender then
+                    warp_listener(true, player.name)
+                elseif current_warp_id then
+                    windower.send_ipc_message('confirm '..current_warp_id..' '..player.name)
                 end
-                current_activity = nil
                 return true
             end
             return true
@@ -1226,15 +1284,37 @@ end
 local function limbus_state_reader(executor)
     if executor then
         local limbus_warp_retainer = current_activity.action_queue[4]
-        --print("Scheduling position check for 5s.")
-        movement_confirm:schedule(5, limbus_warp_retainer)
+        movement_confirm:schedule(8, false, limbus_warp_retainer)
     else
-        if current_activity.action_index == 1 then
-            --print("Resetting our flags, a new warp sequence has started in earnest.")
+        local phase = current_activity.action_index
+        if phase == 1 then
             state.warp_interrupted = false
-        elseif current_activity.action_index == 4 then
-            --print("Confirmed Warp")
-            state.warp_confirmed = true
+            return false
+        elseif not phase == 4 then -- Early exit for 2 and 3
+            return false
+        elseif phase == 4 then
+            if not movement_confirm(true) then
+                state.warp_confirmed = false
+                state.warp_interrupted = true
+                reset(true)
+                debug('Post-warp menu confirm stage reached and no movement detected, evading invalid state; Aborted warp, retrying if necessary...')
+                if not movement_confirm(true) then  -- Sometimes when the warp has reached this phase the release can trigger the server to move you. 
+                    if not current_activity and state.loop_count > 0 then
+                        handle_warp:schedule(0.5, state.current_warp, state.current_args, false, state.loop_count - 1, state.current_sub_cmd)
+                    end
+                else
+                    local player = windower.ffxi.get_mob_by_target('me')
+                    if player.name == warp_sender then
+                        warp_listener(true, player.name)
+                    elseif current_warp_id then
+                        windower.send_ipc_message('confirm '..current_warp_id..' '..player.name)
+                    end
+                end
+                return true
+            else
+                state.warp_confirmed = true
+                return false
+            end
         end
     end
 end
@@ -1244,6 +1324,14 @@ local function perform_next_action()
         local current_action = current_activity.action_queue[current_activity.action_index]
         if current_action == nil then
             debug("all actions complete")
+            if current_warp_id then
+                local player = windower.ffxi.get_mob_by_target('me').name
+                if player == warp_sender then
+                    warp_listener(true, player)
+                else
+                    windower.send_ipc_message('confirm '..current_warp_id..' '..player)
+                end
+            end
             if last_action and last_action.expecting_zone then
                 debug("expecting zone")
                 -- we're going to zone. 
@@ -1261,28 +1349,26 @@ local function perform_next_action()
         elseif not state.fast_retry and current_action.wait_packet then
             debug("waiting for packet 0x"..current_action.wait_packet:hex().." for action "..tostring(current_activity.action_index)..' '..(current_action.description or ''))
             current_action.wait_start = os.time()
-            if not current_action.timeout then 
+            if not current_action.timeout then
                 current_action.timeout = settings.default_packet_wait_timeout
             end
-            local fn = function(s, ca, i, p, d)
-                if state.retry_scheduled then
-                    state.retry_scheduled = false
-                end
-                if ca and ca.action_index == i and not ca.canceled then
+            local fn = function(s, ca, i, p, d, wi)
+                local action = ca.action_queue[i]
+                if action and ca.action_index == i and wi == warp_ident and action.wait_packet == p and not ca.canceled then --We no longer get false timeouts which would thwart otherwise would be successful warps.
                     debug("timed out waiting for packet 0x"..p:hex().." for action "..tostring(i)..' '..(d or ''))
                     if s.loop_count > 0 then
                         reset(true)
                         log("Timed out waiting for response from the menu. Retrying...")
-                        handle_warp:schedule(settings.retry_delay, s.current_warp, s.current_args, false, s.loop_count - 0.2)
+                        handle_warp:schedule(settings.retry_delay, s.current_warp, s.current_args, false, s.loop_count - 0.2, s.current_sub_cmd)
                     else
                         reset(true)
                         log("Timed out waiting for response from the menu.")
                     end
                 end
             end
-            if not state.retry_scheduled then  -- Only allow one fn() call to be scheduled at a time. Increase accountability.
-                state.retry_scheduled = true
-                fn:schedule(current_action.timeout, state, current_activity, current_activity.action_index, current_action.wait_packet, current_action.description)
+            fn:schedule(current_action.timeout, state, current_activity, current_activity.action_index, current_action.wait_packet, current_action.description, warp_ident)
+            if in_limbus_zone and current_activity.action_index == 4 then  -- Often when limbus warps have gotten to this point and then get interrupted from being attacked the warp can still go through leading to missing data bar for that floor. Handle these cases by scheduling a check.
+                limbus_state_reader(true)
             end
         elseif not state.fast_retry and current_action.delay and current_action.delay > 0 then
             debug("delaying action "..tostring(current_activity.action_index)..' '..(current_action.description or '')..' for '.. current_action.delay..'s...')
@@ -1290,12 +1376,16 @@ local function perform_next_action()
             current_action.delay = nil
             last_action = current_action
             perform_next_action:schedule(delay_seconds)
-            if in_limbus_zone and current_activity.action_index == 4 then  -- Often when limbus warps have gotten to this point and then get interrupted from being attacked the warp can still go through leading to missing data bar for that floor. Handle these cases by scheduling a check.
-                limbus_state_reader(true)
-            end
         elseif current_action.packet then
-            if in_limbus_zone then  --Simple flag check to gate further checks, no further checks outside of limbus.
-                limbus_state_reader()
+            if in_limbus_zone then  --Outside limbus skip.
+                if limbus_state_reader() then --If it is true that we have not yet moved stop this function from injecting packet.
+                    if current_activity then
+                        state.loop_count = 0
+                        reset(true)
+                        -- Asynchronous / race-conditions could theoretically allow for this point to be reached. Need more data.
+                    end
+                    return
+                end
             end
             -- just a packet, inject it.
             debug("injecting packet "..tostring(current_activity.action_index)..' '..(current_action.description or ''))
@@ -1332,11 +1422,16 @@ end
 windower.register_event('incoming chunk',function(id,data,modified,injected,blocked)
     if current_activity and current_activity.action_queue and current_activity.running then
         local current_action = current_activity.action_queue[current_activity.action_index]
-        if current_action and current_action.wait_packet and current_action.wait_packet == id then
-            debug("received packet 0x"..id:hex().." for action "..tostring(current_activity.action_index)..' '..(current_action.description or ''))
-            current_action.wait_packet = nil
-            current_action.incoming_packet = packets.parse('incoming',data)
-            perform_next_action()
+        if current_action and current_action.wait_packet and current_action.wait_packet == id and not state.warp_interrupted then
+            local message_type = data:unpack('b4', 5)
+            if id ~= 0x052 or id == 0x052 and message_type ~= 2 then -- Block event skips from triggering wait packet confirmation.     
+                debug("received packet 0x"..id:hex().." for action "..tostring(current_activity.action_index)..' '..(current_action.description or ''))
+                current_action.wait_packet = nil
+                current_action.incoming_packet = packets.parse('incoming',data)
+                perform_next_action()
+            else
+                debug("Detected event skip while waiting to receive packet 0x"..id:hex().." for action "..tostring(current_activity.action_index)..' '..(current_action.description or ''))
+            end
         end
     end
     ----
@@ -1388,7 +1483,7 @@ windower.register_event('incoming chunk',function(id,data,modified,injected,bloc
             end
         end
     end
-    ----
+    ---
     if id == 0x37 and not injected and state.client_lock then
         local p = packets.parse('incoming', data)
         p['_flags3'] = bit.bor(p['_flags3'], 2)
@@ -1402,11 +1497,11 @@ windower.register_event('incoming chunk',function(id,data,modified,injected,bloc
                 if settings.enable_fast_retry_on_interrupt then
                     log("Detected event-skip. Retrying (fast)...")
                     state.warp_interrupted = true
-                    handle_warp:schedule(0.1, state.current_warp, state.current_args, true, state.loop_count - 0.2)
+                    handle_warp:schedule(0.1, state.current_warp, state.current_args, true, state.loop_count - 0.2, state.current_sub_cmd)
                 else
                     log("Detected event-skip. Retrying...")
                     state.warp_interrupted = true
-                    handle_warp:schedule(0.1, state.current_warp, state.current_args, false, state.loop_count - 0.2)
+                    handle_warp:schedule(0.1, state.current_warp, state.current_args, false, state.loop_count - 0.2, state.current_sub_cmd)
                 end
             end
         end
@@ -1510,7 +1605,7 @@ windower.register_event('incoming chunk',function(id,data,modified,injected,bloc
         elseif current_activity then
             debug("Prevented menu from blocking packet exchanges, reading state machine...")
             local i = current_activity and current_activity.action_index
-            local ident = current_activity.warp_ident -- Capture Warp ID now and check in 5 seconds to determine whether a reset is needed.  (State machine accountability improvement)
+            local ident = current_activity.warp_ident -- Capture Warp ID now and check in 5 seconds to determine whether a reset is needed.
             read_warp_state:schedule(5, i, ident)
             return true
         end
@@ -1602,12 +1697,10 @@ end)
 windower.register_event('load', function()
     if not settings.understood then
         windower.add_to_chat(207,'\n Welcome to superwarp 1.1.1. Now use sw in place of  hp, wp, sg, un, so, li, ew, ab etc -  for all warp commands!!\n The new smart-command is "//sw" by itself. It autohandles all warp scenarios where a destination need not be specified. i.e. so port or ab enter. It works as any subcommand for any map except others where multiple are usable, in those cases it always serves as one. i.e. next cmd for limbus.')
-        windower.add_to_chat(207,' All legacy functionality is unchanged.')
-        windower.add_to_chat(207,' The interrupt/retry system has been re-tooled to make it more focused and intentional. It is no longer possible to have an additional warp go through from a single command when attacked and interrupted during warp procedure. (No more basement re-entries in Sortie.) Limbus warp interrupts can no longer result in missing data bars.')
+        windower.add_to_chat(207,' All legacy functionality is still in place.')
         windower.add_to_chat(207,' sw help to list all information.')
         windower.add_to_chat(207,' sw understood to stop displaying these messages on load.')
     end
-    windower.add_to_chat(207,' sw help to list all information.')
 end)
 windower.register_event('login', function()
     player_info = windower.ffxi.get_player()


### PR DESCRIPTION
- Fixed waypoint fuzzyfind so now user may type  //sw vent    or other shorthand and go to inventors coalition  or in another example //sw peac   to go to peacekeepers' coalition.
- Fixed a bug that could occur with the limbus chest tracking part of the limbus next / random commands wherein if the user opened a chest out of order, the tracking could be invalid.
- Added Mog Garden zoning. 
- Command to sync all characters chest tracking with the sender of //sw sync.
- Command to manually set chest open order. //sw chest nw   i.e.
- Command added to toggle default homepoint destinations between legacy and new.
- Command added to toggle readout for sendall warp progress, which immediately alerts players to a character not warping immediately.
- CN destinations added to limbus map.
- Sortie warp unlocks no longer dependent on inventory loading for temp item checks.
- Major improvements in interrupt / retry system.
- Used vectors module for Euclidean distance check in npc scan and increased the max distance for npcs to 25.